### PR TITLE
fix: rewrote PKGBUILD according to Arch packaging guidelines

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,24 +1,40 @@
 # Maintainer: alexm-dev <runa-dev@proton.me>
+# Contributor: Luis Martinez <luis dot martinez at disroot dot org>
+
 pkgname=runa
-_pkgname=runa-tui
 pkgver=0.3.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A fast and lightweight console file browser written in Rust"
 arch=('x86_64' 'aarch64')
 url="https://github.com/alexm-dev/runa"
 license=('MIT')
 depends=('gcc-libs')
-makedepends=('rust' 'cargo')
-source=("$_pkgname-$pkgver.tar.gz::https://static.crates.io/crates/$_pkgname/$_pkgname-$pkgver.crate")
-sha256sums=('e06bb6881476a2f9711a9ad009db2252c574056561c42b59837d3d1a50b38207')
+makedepends=('cargo')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha256sums=('4c85df83d72557239b5a4b8c2155f6234dd38a1d780d23391e9889e22253eaf2')
+
+prepare() {
+    export RUSTUP_TOOLCHAIN=stable
+    cd "$pkgname-$pkgver"
+    cargo fetch --locked --target "$(rustc --print host-tuple)"
+}
 
 build() {
-    cd "$_pkgname-$pkgver"
-    cargo build --release --locked
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cd "$pkgname-$pkgver"
+    cargo build --frozen --release --all-features
+}
+
+check() {
+    export RUSTUP_TOOLCHAIN=stable
+    cd "$pkgname-$pkgver"
+    cargo test --frozen --all-features
 }
 
 package() {
-    cd "$_pkgname-$pkgver"
-    install -Dm755 "target/release/rn" "$pkgdir/usr/bin/rn"
-    install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    cd "$pkgname-$pkgver"
+    install -Dm755 target/release/rn -t "$pkgdir/usr/bin/"
+    install -Dm644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+    install -Dm644 docs/configuration.md -t "$pkgdir/usr/share/docs/$pkgname/"
 }


### PR DESCRIPTION
Hi, I found this project through the AUR, but I noticed the PKGBUILD needed a bit of work.

Arch Linux package maintainers keep a guideline for packaging that AUR contributors are encouraged to abide by.

See here for more information specifically for Rust packaging: https://wiki.archlinux.org/title/Rust_package_guidelines

In short, this patch:

* adds a prepare() function to pull in dependencies so that runa builds entirely offline in the build step
* uses the tarball from the GitHub repo as opposed to the crate. Arch maintainers discourage using the crates if a tarball is readily available.
* cleans up the build() function. The guidelines have changed from using `--locked` to `--frozen` instead to guarantee an offline build

For this patch, I have bumped `pkgrel` to 2 because this update only affects the PKGBUILD. In future releases, you (or whoever makes your releases) must reset this to 1 if `pkgver` changes.

Hope this all helps!

Luis