### PR TITLE
runa theme improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "finl_unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/alexm-dev/runa"
 documentation = "https://docs.rs/runa-tui"
 readme = "README.md"
 authors = ["alexm-dev"]
-rust-version = "1.85"
 categories = ["filesystem", "command-line-utilities", "command-line-interface"]
 keywords = ["file-browser", "file-manager", "tui", "cli", "search"]
 
@@ -21,7 +20,7 @@ dirs = "6.0.0"
 ratatui = "0.30.0"
 crossterm = "0.29.0"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.9.10"
+toml = "0.9"
 crossbeam-channel = "0.5"
 unicode-width = "0.2.2"
 humansize = "2.1.3"
@@ -45,7 +44,7 @@ opt-level = 3
 lto = true
 codegen-units = 1
 panic = "abort"
-strip = "debuginfo"
+strip = true
 debug = false
 
 [profile.release-windows]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,9 +145,13 @@ position = "default"
 
 ## Theme Configuration
 
+The easiest way to change colors:  
+Just set the colors you care about directly under `[theme]`, you only need to override what you want.
+
 ```toml
 [theme]
 # The name of the preset themes included in runa.
+# Choose a preset, or leave as "default" or omit.
 name = "default"
 # Available options (case-sensitive strings):
 #   "gruvbox-dark"
@@ -164,8 +168,6 @@ name = "default"
 #   "tokyonight-day"
 #   "everforest"
 #   "rose-pine"       # or "rose_pine"
-# Example:
-# name = "gruvbox-dark"
 
 # Coloring option for the symling indicator on the entries.
 symlink = "default"
@@ -173,6 +175,11 @@ symlink = "default"
 # The symbol for the current selection. Use "" or " " to disable.
 selection_icon = ">"
 
+# Change your favorite colors easily, no need for full tables or advanced options!
+accent.fg = "#e9a"
+selection.bg = "#204488"
+directory.fg = "cyan"
+# ... add any .fg or .bg of the available options you like.
 ```
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@
 pub mod display;
 pub mod input;
 pub mod load;
+pub mod presets;
 pub mod theme;
 
 pub use display::Display;

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -372,6 +372,7 @@ pub enum BorderShape {
     Square,
     Rounded,
     Double,
+    Thick,
 }
 
 /// Public methods for accessing border shape options
@@ -381,6 +382,7 @@ impl BorderShape {
             BorderShape::Square => BorderType::Plain,
             BorderShape::Rounded => BorderType::Rounded,
             BorderShape::Double => BorderType::Double,
+            BorderShape::Thick => BorderType::Thick,
         }
     }
 }

--- a/src/config/presets.rs
+++ b/src/config/presets.rs
@@ -1,0 +1,259 @@
+//! Preset themes for the runa
+//!
+//! This module defines several preset themes that can be used in runa.
+//! Each theme is created using a specific color palette and a unique name.
+
+use crate::config::Theme;
+use crate::config::theme::{Palette, make_theme};
+
+const TOKYO_STORM: Palette = Palette {
+    base: (36, 40, 59),
+    surface: (41, 46, 66),
+    overlay: (86, 95, 137),
+    primary: (187, 154, 247),
+    secondary: (125, 207, 255),
+    directory: (122, 162, 247),
+};
+
+const TOKYO_NIGHT: Palette = Palette {
+    base: (26, 27, 38),
+    surface: (44, 51, 78),
+    overlay: (86, 95, 137),
+    primary: (187, 154, 247),
+    secondary: (125, 207, 255),
+    directory: (122, 162, 247),
+};
+
+const TOKYO_DAY: Palette = Palette {
+    base: (225, 226, 231),
+    surface: (196, 199, 209),
+    overlay: (168, 175, 199),
+    primary: (152, 94, 171),
+    secondary: (52, 90, 183),
+    directory: (52, 90, 183),
+};
+
+pub fn tokyonight_storm() -> Theme {
+    make_theme("tokyonight-storm", TOKYO_STORM, "┃")
+}
+pub fn tokyonight_night() -> Theme {
+    make_theme("tokyonight-night", TOKYO_NIGHT, "┃")
+}
+pub fn tokyonight_day() -> Theme {
+    make_theme("tokyonight-day", TOKYO_DAY, "┃")
+}
+
+const GRUV_DARK_HARD: Palette = Palette {
+    base: (29, 32, 33),
+    surface: (60, 56, 54),
+    overlay: (146, 131, 116),
+    primary: (211, 134, 155),
+    secondary: (142, 192, 124),
+    directory: (131, 165, 152),
+};
+
+const GRUV_DARK: Palette = Palette {
+    base: (40, 40, 40),
+    surface: (60, 56, 54),
+    overlay: (146, 131, 116),
+    primary: (211, 134, 155),
+    secondary: (142, 192, 124),
+    directory: (131, 165, 152),
+};
+
+const GRUV_LIGHT: Palette = Palette {
+    base: (251, 241, 199),
+    surface: (213, 196, 161),
+    overlay: (124, 111, 100),
+    primary: (143, 63, 113),
+    secondary: (66, 123, 88),
+    directory: (7, 102, 120),
+};
+
+pub fn gruvbox_dark_hard() -> Theme {
+    make_theme("gruvbox-dark-hard", GRUV_DARK_HARD, "*")
+}
+pub fn gruvbox_dark() -> Theme {
+    make_theme("gruvbox-dark", GRUV_DARK, "*")
+}
+pub fn gruvbox_light() -> Theme {
+    make_theme("gruvbox-light", GRUV_LIGHT, "*")
+}
+
+const MOCHA: Palette = Palette {
+    base: (30, 30, 46),
+    surface: (49, 50, 68),
+    overlay: (108, 112, 134),
+    primary: (203, 166, 247),
+    secondary: (148, 226, 213),
+    directory: (137, 180, 250),
+};
+
+const FRAPPE: Palette = Palette {
+    base: (48, 52, 70),
+    surface: (65, 69, 89),
+    overlay: (115, 121, 148),
+    primary: (202, 158, 230),
+    secondary: (129, 200, 190),
+    directory: (140, 170, 238),
+};
+
+const LATTE: Palette = Palette {
+    base: (239, 241, 245),
+    surface: (204, 208, 218),
+    overlay: (156, 160, 176),
+    primary: (136, 57, 239),
+    secondary: (23, 146, 153),
+    directory: (30, 102, 245),
+};
+
+pub fn catppuccin_mocha() -> Theme {
+    make_theme("catppuccin-mocha", MOCHA, "┃")
+}
+pub fn catppuccin_frappe() -> Theme {
+    make_theme("catppuccin-frappe", FRAPPE, "┃")
+}
+pub fn catppuccin_latte() -> Theme {
+    make_theme("catppuccin-latte", LATTE, "┃")
+}
+
+const CARBON: Palette = Palette {
+    base: (22, 22, 22),
+    surface: (42, 42, 42),
+    overlay: (82, 82, 82),
+    primary: (190, 149, 233),
+    secondary: (61, 187, 199),
+    directory: (120, 169, 235),
+};
+
+const NIGHTFOX: Palette = Palette {
+    base: (25, 30, 36),
+    surface: (43, 51, 63),
+    overlay: (87, 91, 112),
+    primary: (195, 157, 239),
+    secondary: (99, 199, 209),
+    directory: (113, 161, 236),
+};
+
+pub fn carbonfox() -> Theme {
+    make_theme("carbonfox", CARBON, "┃")
+}
+pub fn nightfox() -> Theme {
+    make_theme("nightfox", NIGHTFOX, "┃")
+}
+
+const FOREST: Palette = Palette {
+    base: (43, 51, 57),
+    surface: (74, 82, 88),
+    overlay: (133, 146, 137),
+    primary: (167, 192, 128),
+    secondary: (230, 126, 128),
+    directory: (127, 187, 179),
+};
+
+const ROSE_PINE: Palette = Palette {
+    base: (25, 23, 36),
+    surface: (31, 29, 46),
+    overlay: (110, 106, 134),
+    primary: (196, 167, 231),
+    secondary: (235, 188, 186),
+    directory: (49, 116, 143),
+};
+
+pub fn everforest() -> Theme {
+    make_theme("everforest", FOREST, "*")
+}
+pub fn rose_pine() -> Theme {
+    make_theme("rose_pine", ROSE_PINE, "*")
+}
+
+const NORD: Palette = Palette {
+    base: (46, 52, 64),
+    surface: (67, 76, 94),
+    overlay: (94, 129, 172),
+    primary: (163, 190, 140),
+    secondary: (191, 97, 106),
+    directory: (129, 161, 193),
+};
+
+pub fn nord() -> Theme {
+    make_theme("nord", NORD, "*")
+}
+
+const TWO_DARK: Palette = Palette {
+    base: (40, 44, 52),
+    surface: (33, 37, 43),
+    overlay: (92, 99, 112),
+    primary: (97, 175, 239),
+    secondary: (198, 120, 221),
+    directory: (229, 192, 123),
+};
+
+pub fn two_dark() -> Theme {
+    make_theme("two-dark", TWO_DARK, "*")
+}
+
+const ONE_DARK: Palette = Palette {
+    base: (40, 44, 52),
+    surface: (56, 60, 69),
+    overlay: (97, 102, 117),
+    primary: (97, 175, 239),
+    secondary: (198, 120, 221),
+    directory: (229, 192, 123),
+};
+
+pub fn one_dark() -> Theme {
+    make_theme("one-dark", ONE_DARK, "*")
+}
+
+const SOLARIZED_DARK: Palette = Palette {
+    base: (0, 43, 54),
+    surface: (7, 54, 66),
+    overlay: (101, 123, 131),
+    primary: (38, 139, 210),
+    secondary: (211, 54, 130),
+    directory: (42, 161, 152),
+};
+
+const SOLARIZED_LIGHT: Palette = Palette {
+    base: (253, 246, 227),
+    surface: (238, 232, 213),
+    overlay: (101, 123, 131),
+    primary: (38, 139, 210),
+    secondary: (211, 54, 130),
+    directory: (42, 161, 152),
+};
+
+pub fn solarized_dark() -> Theme {
+    make_theme("solarized-dark", SOLARIZED_DARK, "*")
+}
+
+pub fn solarized_light() -> Theme {
+    make_theme("solarized-light", SOLARIZED_LIGHT, "*")
+}
+
+const DRACULA: Palette = Palette {
+    base: (40, 42, 54),
+    surface: (68, 71, 90),
+    overlay: (139, 233, 253),
+    primary: (255, 121, 198),
+    secondary: (80, 250, 123),
+    directory: (189, 147, 249),
+};
+
+pub fn dracula() -> Theme {
+    make_theme("dracula", DRACULA, "┃")
+}
+
+const MONOKAI: Palette = Palette {
+    base: (39, 40, 34),
+    surface: (49, 51, 43),
+    overlay: (117, 113, 94),
+    primary: (249, 38, 114),
+    secondary: (166, 226, 46),
+    directory: (102, 217, 239),
+};
+
+pub fn monokai() -> Theme {
+    make_theme("monokai", MONOKAI, "┃")
+}

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -5,8 +5,10 @@
 //!
 //! Also holds the internal themes and the logic to apply user overrides on top of them.
 
+use crate::config::presets::*;
 use crate::ui::widgets::{DialogPosition, DialogSize};
 use crate::utils::parse_color;
+
 use once_cell::sync::Lazy;
 use ratatui::style::{Color, Style};
 use serde::Deserialize;
@@ -158,6 +160,23 @@ impl Theme {
         self.symlink.or(Theme::internal_defaults().symlink)
     }
 
+    // Pane-specific style getters
+
+    pub fn parent_selection_style(&self) -> Style {
+        self.parent.selection_style(&self.selection)
+    }
+
+    pub fn preview_selection_style(&self) -> Style {
+        self.preview.selection_style(&self.selection)
+    }
+
+    pub fn preview_item_style(&self) -> Style {
+        self.preview.entry_style(&self.entry)
+    }
+    pub fn parent_item_style(&self) -> Style {
+        self.parent.entry_style(&self.entry)
+    }
+
     // Accessor methods for various theme properties
 
     pub fn selection_icon(&self) -> &str {
@@ -196,6 +215,18 @@ impl Theme {
             Some("catppuccin-frappe") => Some(catppuccin_frappe()),
             Some("catppuccin-macchiato") => Some(catppuccin_mocha()),
             Some("catppuccin-latte") => Some(catppuccin_latte()),
+
+            Some("nord") => Some(nord()),
+
+            Some("two-dark") => Some(two_dark()),
+            Some("one-dark") => Some(one_dark()),
+
+            Some("solarized-dark") => Some(solarized_dark()),
+            Some("solarized-light") => Some(solarized_light()),
+
+            Some("dracula") => Some(dracula()),
+
+            Some("monokai") => Some(monokai()),
 
             Some("nightfox") => Some(nightfox()),
             Some("carbonfox") => Some(carbonfox()),
@@ -238,6 +269,8 @@ impl Theme {
     fn map_to_bat_theme(internal_theme: &str) -> &'static str {
         match internal_theme {
             "default" => "TwoDark",
+            "two-dark" => "TwoDark",
+            "one-dark" => "OneHalfDark",
             "gruvbox-dark" | "gruvbox-dark-hard" | "gruvbox" => "gruvbox-dark",
             "gruvbox-light" => "gruvbox-light",
             "tokyonight-night" | "tokyonight" | "tokyonight-storm" => "TwoDark",
@@ -246,6 +279,11 @@ impl Theme {
             "catppuccin-macchiato" => "Catppuccin Macchiato",
             "catppuccin-mocha" | "catppuccin" => "Catppuccin Mocha",
             "nightfox" | "carbonfox" | "rose-pine" | "everforest" => "TwoDark",
+            "monokai" => "Monokai Extended (default)",
+            "nord" => "Nord",
+            "solarized-dark" => "Solarized (dark)",
+            "solarized-light" => "Solarized (light)",
+            "dracula" => "Dracula",
             _ => "TwoDark",
         }
     }
@@ -335,6 +373,7 @@ impl ColorPair {
 #[derive(Deserialize, Debug, PartialEq, Clone, Copy, Default)]
 #[serde(default)]
 pub struct PaneTheme {
+    #[serde(flatten)]
     color: ColorPair,
     selection: Option<ColorPair>,
 }
@@ -357,11 +396,15 @@ impl PaneTheme {
         }
     }
 
-    /// Returns the selection style, falling back to the internal default theme's selection style.
-    /// This method uses the internal default theme as the fallback.
-    pub fn selection_style_or_theme(&self) -> Style {
-        let fallback = Theme::internal_defaults().selection;
-        self.selection_style(&fallback)
+    /// Returns the entry style, falling back to the provided fallback ColorPair.
+    /// If entry color is Reset, uses the fallback.
+    ///
+    /// # Arguments
+    /// * `fallback` - A `ColorPair` to use as fallback.
+    /// # Returns
+    /// * `Style` - A `Style` representing the entry style.
+    pub fn entry_style(&self, fallback: &ColorPair) -> Style {
+        self.color.style_or(fallback)
     }
 
     /// Returns the pane color style, falling back to the provided fallback ColorPair.
@@ -444,17 +487,14 @@ pub struct WidgetTheme {
 }
 
 impl WidgetTheme {
-    /// Returns the dialog position.
     pub fn position(&self) -> &Option<DialogPosition> {
         &self.position
     }
 
-    /// Returns the dialog size.
     pub fn size(&self) -> &Option<DialogSize> {
         &self.size
     }
 
-    /// Returns the confirm dialog size.
     pub fn confirm_size(&self) -> &Option<DialogSize> {
         &self.confirm_size
     }
@@ -625,7 +665,6 @@ pub fn make_theme(name: &str, palette: Palette, icon: &str) -> Theme {
             fg: muted,
             ..ColorPair::default()
         },
-
         status_line: ColorPair {
             fg: Color::Reset,
             bg: base_bg,
@@ -667,167 +706,4 @@ pub fn make_theme(name: &str, palette: Palette, icon: &str) -> Theme {
         },
         ..Theme::default()
     }
-}
-
-// Theme palettes
-
-const TOKYO_STORM: Palette = Palette {
-    base: (36, 40, 59),
-    surface: (41, 46, 66),
-    overlay: (86, 95, 137),
-    primary: (187, 154, 247),
-    secondary: (125, 207, 255),
-    directory: (122, 162, 247),
-};
-
-const TOKYO_NIGHT: Palette = Palette {
-    base: (26, 27, 38),
-    surface: (44, 51, 78),
-    overlay: (86, 95, 137),
-    primary: (187, 154, 247),
-    secondary: (125, 207, 255),
-    directory: (122, 162, 247),
-};
-
-const TOKYO_DAY: Palette = Palette {
-    base: (225, 226, 231),
-    surface: (196, 199, 209),
-    overlay: (168, 175, 199),
-    primary: (152, 94, 171),
-    secondary: (52, 90, 183),
-    directory: (52, 90, 183),
-};
-
-pub fn tokyonight_storm() -> Theme {
-    make_theme("tokyonight-storm", TOKYO_STORM, "┃")
-}
-pub fn tokyonight_night() -> Theme {
-    make_theme("tokyonight-night", TOKYO_NIGHT, "┃")
-}
-pub fn tokyonight_day() -> Theme {
-    make_theme("tokyonight-day", TOKYO_DAY, "┃")
-}
-
-const GRUV_DARK_HARD: Palette = Palette {
-    base: (29, 32, 33),
-    surface: (60, 56, 54),
-    overlay: (146, 131, 116),
-    primary: (211, 134, 155),
-    secondary: (142, 192, 124),
-    directory: (131, 165, 152),
-};
-
-const GRUV_DARK: Palette = Palette {
-    base: (40, 40, 40),
-    surface: (60, 56, 54),
-    overlay: (146, 131, 116),
-    primary: (211, 134, 155),
-    secondary: (142, 192, 124),
-    directory: (131, 165, 152),
-};
-
-const GRUV_LIGHT: Palette = Palette {
-    base: (251, 241, 199),
-    surface: (213, 196, 161),
-    overlay: (124, 111, 100),
-    primary: (143, 63, 113),
-    secondary: (66, 123, 88),
-    directory: (7, 102, 120),
-};
-
-pub fn gruvbox_dark_hard() -> Theme {
-    make_theme("gruvbox-dark-hard", GRUV_DARK_HARD, "*")
-}
-pub fn gruvbox_dark() -> Theme {
-    make_theme("gruvbox-dark", GRUV_DARK, "*")
-}
-pub fn gruvbox_light() -> Theme {
-    make_theme("gruvbox-light", GRUV_LIGHT, "*")
-}
-
-const MOCHA: Palette = Palette {
-    base: (30, 30, 46),
-    surface: (49, 50, 68),
-    overlay: (108, 112, 134),
-    primary: (203, 166, 247),
-    secondary: (148, 226, 213),
-    directory: (137, 180, 250),
-};
-
-const FRAPPE: Palette = Palette {
-    base: (48, 52, 70),
-    surface: (65, 69, 89),
-    overlay: (115, 121, 148),
-    primary: (202, 158, 230),
-    secondary: (129, 200, 190),
-    directory: (140, 170, 238),
-};
-
-const LATTE: Palette = Palette {
-    base: (239, 241, 245),
-    surface: (204, 208, 218),
-    overlay: (156, 160, 176),
-    primary: (136, 57, 239),
-    secondary: (23, 146, 153),
-    directory: (30, 102, 245),
-};
-
-pub fn catppuccin_mocha() -> Theme {
-    make_theme("catppuccin-mocha", MOCHA, "┃")
-}
-pub fn catppuccin_frappe() -> Theme {
-    make_theme("catppuccin-frappe", FRAPPE, "┃")
-}
-pub fn catppuccin_latte() -> Theme {
-    make_theme("catppuccin-latte", LATTE, "┃")
-}
-
-const CARBON: Palette = Palette {
-    base: (22, 22, 22),
-    surface: (42, 42, 42),
-    overlay: (82, 82, 82),
-    primary: (190, 149, 233),
-    secondary: (61, 187, 199),
-    directory: (120, 169, 235),
-};
-
-const NIGHTFOX: Palette = Palette {
-    base: (25, 30, 36),
-    surface: (43, 51, 63),
-    overlay: (87, 91, 112),
-    primary: (195, 157, 239),
-    secondary: (99, 199, 209),
-    directory: (113, 161, 236),
-};
-
-pub fn carbonfox() -> Theme {
-    make_theme("carbonfox", CARBON, "┃")
-}
-pub fn nightfox() -> Theme {
-    make_theme("nightfox", NIGHTFOX, "┃")
-}
-
-const FOREST: Palette = Palette {
-    base: (43, 51, 57),
-    surface: (74, 82, 88),
-    overlay: (133, 146, 137),
-    primary: (167, 192, 128),
-    secondary: (230, 126, 128),
-    directory: (127, 187, 179),
-};
-
-const ROSE_PINE: Palette = Palette {
-    base: (25, 23, 36),
-    surface: (31, 29, 46),
-    overlay: (110, 106, 134),
-    primary: (196, 167, 231),
-    secondary: (235, 188, 186),
-    directory: (49, 116, 143),
-};
-
-pub fn everforest() -> Theme {
-    make_theme("everforest", FOREST, "*")
-}
-pub fn rose_pine() -> Theme {
-    make_theme("rose_pine", ROSE_PINE, "*")
 }

--- a/src/ui/icons.rs
+++ b/src/ui/icons.rs
@@ -169,12 +169,13 @@ pub fn nerd_font_icon(entry: &FileEntry) -> &'static str {
         return icon;
     }
 
-    if let Some(dot_idx) = lowercase_name.rfind('.') {
-        if dot_idx > 0 && dot_idx < lowercase_name.len() - 1 {
-            let ext = &lowercase_name[dot_idx + 1..];
-            if let Some(icon) = EXT_ICON_MAP.get(ext) {
-                return icon;
-            }
+    if let Some(dot_idx) = lowercase_name.rfind('.')
+        && dot_idx > 0
+        && dot_idx < lowercase_name.len() - 1
+    {
+        let ext = &lowercase_name[dot_idx + 1..];
+        if let Some(icon) = EXT_ICON_MAP.get(ext) {
+            return icon;
         }
     }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -78,9 +78,9 @@ pub fn render(frame: &mut Frame, app: &mut AppState) {
         );
 
         let parent_pane_style = PaneStyles {
-            item: theme_cfg.parent().effective_style_or_theme(),
+            item: theme_cfg.parent_item_style(),
             dir: theme_cfg.directory_style(),
-            selection: theme_cfg.parent().selection_style_or_theme(),
+            selection: theme_cfg.parent_selection_style(),
             symlink: symlink_style,
         };
 
@@ -181,9 +181,9 @@ pub fn render(frame: &mut Frame, app: &mut AppState) {
         );
 
         let preview_pane_styles = PaneStyles {
-            item: theme_cfg.preview().effective_style_or_theme(),
+            item: theme_cfg.preview_item_style(),
             dir: theme_cfg.directory_style(),
-            selection: theme_cfg.preview().selection_style_or_theme(),
+            selection: theme_cfg.preview_selection_style(),
             symlink: symlink_style,
         };
 


### PR DESCRIPTION
Improved theming by making `[theme.selection]` and `[theme.entry]` the central theming keys for selection and entry coloring with either `[theme.preview.selection.fg]` being overwrites.

### Refactor in config/theme
- Added `presets` config sub module to separate preset themes.
- Added more themes
- Changed how parent and preview panes now use selection and entry theme fields in ui/render

### Cargo.toml changes
- Removed `rust-version` and instead only use `edition = 2024` now.
- Set `strip = true` for best optimization for the release profile