### PR TITLE
Keybind help widget implementation

### DIFF
--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -51,6 +51,7 @@ pub(crate) enum FileAction {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum SystemAction {
     Quit,
+    KeyBindHelp,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -116,6 +117,10 @@ impl Keymap {
             keys.alternate_delete(),
             Action::File(FileAction::AlternateDelete)
         );
+        bind!(
+            keys.keybind_help(),
+            Action::System(SystemAction::KeyBindHelp)
+        );
 
         bind_prefix!(
             keys.go_to_top(),
@@ -142,7 +147,19 @@ impl Keymap {
             code: key.code,
             modifiers: key.modifiers,
         };
-        self.map.get(&k).copied()
+
+        if let Some(action) = self.map.get(&k).copied() {
+            return Some(action);
+        }
+
+        if matches!(key.code, KeyCode::Char(_)) && key.modifiers.contains(KeyModifiers::SHIFT) {
+            let k2 = Key {
+                code: key.code,
+                modifiers: key.modifiers - KeyModifiers::SHIFT,
+            };
+            return self.map.get(&k2).copied();
+        }
+        None
     }
 
     pub(crate) fn gmap(&self) -> &HashMap<KeyCode, PrefixCommand> {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -15,7 +15,7 @@
 //! This is the primary context/state object passed to most UI/Terminal event logic.
 
 use crate::app::actions::{ActionContext, ActionMode, InputMode};
-use crate::app::keymap::{Action, Keymap, SystemAction};
+use crate::app::keymap::{Action, Keymap};
 use crate::app::{NavState, ParentState, PreviewState};
 use crate::config::Config;
 use crate::core::worker::{WorkerResponse, WorkerTask, Workers};
@@ -340,9 +340,17 @@ impl<'a> AppState<'a> {
             return self.handle_input_mode(key);
         }
 
+        if let Some(res) = self.handle_esc_close_overlays(&key) {
+            return res;
+        }
+
+        if let Some(res) = self.handle_prefix_dispatch(&key) {
+            return res;
+        }
+
         if let Some(action) = self.keymap.lookup(key) {
             match action {
-                Action::System(SystemAction::Quit) => return KeypressResult::Quit,
+                Action::System(sys_act) => return self.handle_sys_action(sys_act),
                 Action::Nav(nav_act) => return self.handle_nav_action(nav_act),
                 Action::File(file_act) => return self.handle_file_action(file_act),
             }

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -32,6 +32,7 @@ pub(crate) struct Keys {
     go_to_top: Vec<String>,
     go_to_home: Vec<String>,
     go_to_path: Vec<String>,
+    keybind_help: Vec<String>,
 }
 
 /// Editor configuration options
@@ -41,123 +42,45 @@ pub(crate) struct Editor {
     cmd: String,
 }
 
-/// Public methods for accessing input configuration options
-impl Keys {
-    #[inline]
-    pub(crate) fn open_file(&self) -> &[String] {
-        &self.open_file
-    }
-
-    #[inline]
-    pub(crate) fn go_up(&self) -> &[String] {
-        &self.go_up
-    }
-
-    #[inline]
-    pub(crate) fn go_down(&self) -> &[String] {
-        &self.go_down
-    }
-
-    #[inline]
-    pub(crate) fn go_parent(&self) -> &[String] {
-        &self.go_parent
-    }
-
-    #[inline]
-    pub(crate) fn go_into_dir(&self) -> &[String] {
-        &self.go_into_dir
-    }
-
-    #[inline]
-    pub(crate) fn quit(&self) -> &[String] {
-        &self.quit
-    }
-
-    #[inline]
-    pub(crate) fn delete(&self) -> &[String] {
-        &self.delete
-    }
-
-    #[inline]
-    pub(crate) fn copy(&self) -> &[String] {
-        &self.copy
-    }
-
-    #[inline]
-    pub(crate) fn paste(&self) -> &[String] {
-        &self.paste
-    }
-
-    #[inline]
-    pub(crate) fn rename(&self) -> &[String] {
-        &self.rename
-    }
-
-    #[inline]
-    pub(crate) fn create(&self) -> &[String] {
-        &self.create
-    }
-
-    #[inline]
-    pub(crate) fn create_directory(&self) -> &[String] {
-        &self.create_directory
-    }
-
-    #[inline]
-    pub(crate) fn move_file(&self) -> &[String] {
-        &self.move_file
-    }
-
-    #[inline]
-    pub(crate) fn filter(&self) -> &[String] {
-        &self.filter
-    }
-
-    #[inline]
-    pub(crate) fn toggle_marker(&self) -> &[String] {
-        &self.toggle_marker
-    }
-
-    #[inline]
-    pub(crate) fn show_info(&self) -> &[String] {
-        &self.show_info
-    }
-
-    #[inline]
-    pub(crate) fn find(&self) -> &[String] {
-        &self.find
-    }
-
-    #[inline]
-    pub(crate) fn clear_markers(&self) -> &[String] {
-        &self.clear_markers
-    }
-
-    #[inline]
-    pub(crate) fn clear_filter(&self) -> &[String] {
-        &self.clear_filter
-    }
-
-    #[inline]
-    pub(crate) fn alternate_delete(&self) -> &[String] {
-        &self.alternate_delete
-    }
-
-    #[inline]
-    pub(crate) fn go_to_top(&self) -> &[String] {
-        &self.go_to_top
-    }
-
-    #[inline]
-    pub(crate) fn go_to_home(&self) -> &[String] {
-        &self.go_to_home
-    }
-
-    #[inline]
-    pub(crate) fn go_to_path(&self) -> &[String] {
-        &self.go_to_path
-    }
+macro_rules! accessor {
+    ($($name:ident),+ $(,)?) => {
+        impl Keys {
+            $(
+                #[inline]
+                pub(crate) fn $name(&self) -> &[String] {
+                    &self.$name
+                }
+            )+
+        }
+    };
 }
+
+accessor!(
+    open_file,
+    go_up,
+    go_down,
+    go_parent,
+    go_into_dir,
+    quit,
+    delete,
+    copy,
+    paste,
+    rename,
+    create,
+    create_directory,
+    move_file,
+    filter,
+    toggle_marker,
+    show_info,
+    find,
+    clear_markers,
+    clear_filter,
+    alternate_delete,
+    go_to_top,
+    go_to_home,
+    go_to_path,
+    keybind_help,
+);
 
 /// Default input configuration options
 impl Default for Keys {
@@ -191,6 +114,8 @@ impl Default for Keys {
             go_to_top: vec!["g".into()],
             go_to_home: vec!["h".into()],
             go_to_path: vec!["p".into()],
+
+            keybind_help: vec!["?".into()],
         }
     }
 }

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -55,13 +55,6 @@ where
             match event::read()? {
                 // handle keypress
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    if let Some(prefix) = app.handle_prefix_key(&key)
-                        && app.handle_prefix_action(prefix)
-                    {
-                        terminal.draw(|f| ui::render(f, app))?;
-                        continue;
-                    }
-
                     let result = app.handle_keypress(key);
 
                     match result {

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -13,6 +13,7 @@ pub(crate) enum Overlay {
     ShowInfo { info: FileInfo },
     Message { text: String },
     PreifxHelp,
+    KeybindHelp,
 }
 
 pub(crate) struct OverlayStack {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -363,6 +363,9 @@ fn render_overlays(frame: &mut Frame, app: &AppState, accent_style: Style) {
             Overlay::PreifxHelp => {
                 widgets::draw_prefix_help_overlay(frame, app, accent_style);
             }
+            Overlay::KeybindHelp => {
+                widgets::draw_keybind_help(frame, app, accent_style);
+            }
         }
     }
 }


### PR DESCRIPTION
### Added
- Keybind help: Added new overlay widget with "`?" as default keybind to show current mapped keybinds.

### Changed
- Prefix key handling: Changed how prefix key-handling is implemented. Now `AppState`'s central `handle_keypress` handles all relevant prefix actions.
- Keymap lookup: Possible now to use simple single characters for keybinds instead of ["Shift+/"] or ["Shift+?"].
Now: ["/"] or ["?"]

### Note:
* Keybind help widget still needs work and testing