### PR TITLE
Feature/sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All the changes made to runa are documented here.
 
-## [0.9.2] - UNRELEASED
+## [0.10.0] - UNRELEASED
 
 #### Performance improvement patch. Improves efficiency of file information for the status line and the widget.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "runa-tui"
-version = "0.9.2-beta.1"
+version = "0.10.0-alpha.1"
 dependencies = [
  "ansi-to-tui",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "runa-tui"
 description = "A fast, keyboard-focused terminal file manager (TUI). Highly configurable and lightweight."
-version = "0.9.2-beta.1"
+version = "0.10.0-alpha.1"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT OR Apache-2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ pub(crate) mod actions;
 pub(crate) mod handlers;
 pub(crate) mod keymap;
 pub(crate) mod metadata;
-mod nav;
+pub(crate) mod nav;
 mod parent;
 pub(crate) mod preview;
 mod state;

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -80,6 +80,7 @@ impl ActionContext {
         input_buffer: &str,
         input_cursor_pos: usize,
         scroll: &ScrollState,
+        prefix_recognizer: &KeyPrefix,
     }
 
     pub(crate) fn prefix_recognizer_mut(&mut self) -> &mut KeyPrefix {

--- a/src/app/handlers/input_mode.rs
+++ b/src/app/handlers/input_mode.rs
@@ -190,12 +190,13 @@ impl<'a> AppState<'a> {
         key: &KeyEvent,
     ) -> Option<KeypressResult> {
         let gmap = self.keymap.gmap();
+        let sort_map = self.keymap.sortmap();
 
         let (started, exited, result, consumed) = {
             let prefix = self.actions.prefix_recognizer_mut();
-            let was_g = prefix.is_g_state();
+            let was_g = prefix.is_g_state() || prefix.is_sort_state();
 
-            let result = prefix.feed(key, gmap);
+            let result = prefix.feed(key, gmap, sort_map);
 
             let consumed = was_g && key.code == Esc;
 
@@ -240,6 +241,31 @@ impl<'a> AppState<'a> {
             PrefixCommand::Nav(NavAction::GoToPath) => {
                 self.prompt_go_to_path();
                 self.refresh_show_info_if_open();
+            }
+            PrefixCommand::Sort(sort_mode) => {
+                use crate::app::nav::{SortConfig, SortOrder};
+
+                let mut sort_config: SortConfig = self.nav.sort_config();
+
+                if sort_config.mode == sort_mode {
+                    sort_config.order = sort_config.order.toggle();
+                } else {
+                    sort_config.mode = sort_mode;
+                    sort_config.order = SortOrder::Ascending;
+                }
+
+                self.nav.set_sort_config(sort_config);
+
+                let focus = self
+                    .nav
+                    .selected_entry()
+                    .map(|file_entry| file_entry.name().to_os_string());
+
+                self.request_dir_load(workers, focus);
+                self.refresh_show_info_if_open();
+                self.parent.clear();
+                self.request_parent_content(workers);
+                self.request_preview(workers);
             }
             _ => return false,
         }

--- a/src/app/handlers/input_mode.rs
+++ b/src/app/handlers/input_mode.rs
@@ -13,6 +13,7 @@
 use crate::app::Workers;
 use crate::app::actions::{ActionMode, InputMode};
 use crate::app::keymap::{Action, NavAction, PrefixCommand, SystemAction};
+use crate::app::nav::{SortConfig, SortOrder};
 use crate::app::state::{AppState, KeypressResult};
 use crate::core::proc::{complete_dirs_with_fd, fd_binary};
 use crate::ui::overlays::OverlayKind;
@@ -245,8 +246,6 @@ impl<'a> AppState<'a> {
                 self.refresh_show_info_if_open();
             }
             PrefixCommand::Sort(sort_mode) => {
-                use crate::app::nav::{SortConfig, SortOrder};
-
                 let mut sort_config: SortConfig = self.nav.sort_config();
 
                 if sort_config.mode == sort_mode {
@@ -263,7 +262,7 @@ impl<'a> AppState<'a> {
                     .selected_entry()
                     .map(|file_entry| file_entry.name().to_os_string());
 
-                self.request_dir_load(workers, focus);
+                self.request_dir_resort(workers, focus);
                 self.request_parent_content(workers);
                 self.request_preview(workers);
             }

--- a/src/app/handlers/input_mode.rs
+++ b/src/app/handlers/input_mode.rs
@@ -262,8 +262,6 @@ impl<'a> AppState<'a> {
                     .map(|file_entry| file_entry.name().to_os_string());
 
                 self.request_dir_load(workers, focus);
-                self.refresh_show_info_if_open();
-                self.parent.clear();
                 self.request_parent_content(workers);
                 self.request_preview(workers);
             }

--- a/src/app/handlers/input_mode.rs
+++ b/src/app/handlers/input_mode.rs
@@ -195,8 +195,10 @@ impl<'a> AppState<'a> {
         let (started, exited, result, consumed) = {
             let prefix = self.actions.prefix_recognizer_mut();
             let was_g = prefix.is_g_state() || prefix.is_sort_state();
+            let g_prefix = self.keymap.g_prefix();
+            let sort_prefix = self.keymap.sort_prefix();
 
-            let result = prefix.feed(key, gmap, sort_map);
+            let result = prefix.feed(key, gmap, sort_map, sort_prefix, g_prefix);
 
             let consumed = was_g && key.code == Esc;
 

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -91,6 +91,8 @@ pub(crate) struct Keymap {
     map: HashMap<Key, Action>,
     gmap: HashMap<KeyCode, PrefixCommand>,
     sortmap: HashMap<KeyCode, PrefixCommand>,
+    g_prefix: Vec<Key>,
+    sort_prefix: Vec<Key>,
 }
 
 impl Keymap {
@@ -101,6 +103,16 @@ impl Keymap {
         let mut gmap = HashMap::new();
         let mut sortmap = HashMap::new();
         let keys = config.keys();
+        let sort_prefix: Vec<Key> = keys
+            .sort().iter()
+            .filter_map(|k| parse_key(k))
+            .collect();
+
+        let g_prefix: Vec<Key> = keys
+            .prefix_go_to()
+            .iter()
+            .filter_map(|k| parse_key(k))
+            .collect();
 
         macro_rules! bind {
             ($keys:expr, $action:expr) => {
@@ -171,7 +183,7 @@ impl Keymap {
         sortmap.insert(KeyCode::Char('e'), PrefixCommand::Sort(SortMode::Extension));
         sortmap.insert(KeyCode::Char('z'), PrefixCommand::Sort(SortMode::Natural));
 
-        Keymap { map, gmap, sortmap }
+        Keymap { map, gmap, sortmap, g_prefix, sort_prefix }
     }
 
     /// Looks up the action for a given key event
@@ -210,6 +222,11 @@ impl Keymap {
     pub(crate) fn sortmap(&self) -> &HashMap<KeyCode, PrefixCommand> {
         &self.sortmap
     }
+
+    crate::getters! {
+        sort_prefix: &[Key],
+        g_prefix: &[Key],
+    }
 }
 
 pub(crate) struct KeyPrefix {
@@ -243,20 +260,25 @@ impl KeyPrefix {
         key: &KeyEvent,
         gmap: &HashMap<KeyCode, PrefixCommand>,
         sortmap: &HashMap<KeyCode, PrefixCommand>,
+        sort_prefix: &[Key],
+        g_prefix: &[Key],
     ) -> Option<PrefixCommand> {
         self.started = false;
         self.exited = false;
         let now = Instant::now();
         match self.state {
             PrefixState::None => {
-                if key.code == KeyCode::Char('g') && key.modifiers.is_empty() {
+                let k = Key {
+                    code: key.code,
+                    modifiers: key.modifiers,
+                };
+
+                if g_prefix.contains(&k) {
                     self.state = PrefixState::G;
                     self.last_time = Some(now);
                     self.started = true;
                     None
-                } else if key.code == KeyCode::Char('v')
-                    && (key.modifiers.contains(KeyModifiers::CONTROL) || key.modifiers.is_empty())
-                {
+                } else if sort_prefix.contains(&k) {
                     self.state = PrefixState::Sort;
                     self.last_time = Some(now);
                     self.started = true;

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -4,6 +4,7 @@
 //! for all navigation, file and actions used by runa.
 
 use crate::Config;
+use crate::app::nav::SortMode;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::collections::HashMap;
@@ -75,6 +76,7 @@ pub(crate) enum SystemAction {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum PrefixCommand {
     Nav(NavAction),
+    Sort(SortMode),
 }
 
 /// Key + modifiers as used in keybind/keymap
@@ -88,6 +90,7 @@ pub(crate) struct Key {
 pub(crate) struct Keymap {
     map: HashMap<Key, Action>,
     gmap: HashMap<KeyCode, PrefixCommand>,
+    sortmap: HashMap<KeyCode, PrefixCommand>,
 }
 
 impl Keymap {
@@ -96,6 +99,7 @@ impl Keymap {
     pub(crate) fn from_config(config: &Config) -> Self {
         let mut map = HashMap::new();
         let mut gmap = HashMap::new();
+        let mut sortmap = HashMap::new();
         let keys = config.keys();
 
         macro_rules! bind {
@@ -159,7 +163,15 @@ impl Keymap {
         bind_prefix!(keys.go_to_home(), Action::Nav(N::GoToHome), PrefixCommand::Nav(N::GoToHome));
         bind_prefix!(keys.go_to_path(), Action::Nav(N::GoToPath), PrefixCommand::Nav(N::GoToPath));
 
-        Keymap { map, gmap }
+        sortmap.insert(KeyCode::Char('n'), PrefixCommand::Sort(SortMode::Name));
+        sortmap.insert(KeyCode::Char('m'), PrefixCommand::Sort(SortMode::Modified));
+        sortmap.insert(KeyCode::Char('c'), PrefixCommand::Sort(SortMode::Created));
+        sortmap.insert(KeyCode::Char('a'), PrefixCommand::Sort(SortMode::Accessed));
+        sortmap.insert(KeyCode::Char('s'), PrefixCommand::Sort(SortMode::Size));
+        sortmap.insert(KeyCode::Char('e'), PrefixCommand::Sort(SortMode::Extension));
+        sortmap.insert(KeyCode::Char('z'), PrefixCommand::Sort(SortMode::Natural));
+
+        Keymap { map, gmap, sortmap }
     }
 
     /// Looks up the action for a given key event
@@ -194,6 +206,10 @@ impl Keymap {
     pub(crate) fn gmap(&self) -> &HashMap<KeyCode, PrefixCommand> {
         &self.gmap
     }
+
+    pub(crate) fn sortmap(&self) -> &HashMap<KeyCode, PrefixCommand> {
+        &self.sortmap
+    }
 }
 
 pub(crate) struct KeyPrefix {
@@ -208,6 +224,7 @@ pub(crate) struct KeyPrefix {
 enum PrefixState {
     None,
     G,
+    Sort,
 }
 
 impl KeyPrefix {
@@ -225,6 +242,7 @@ impl KeyPrefix {
         &mut self,
         key: &KeyEvent,
         gmap: &HashMap<KeyCode, PrefixCommand>,
+        sortmap: &HashMap<KeyCode, PrefixCommand>,
     ) -> Option<PrefixCommand> {
         self.started = false;
         self.exited = false;
@@ -233,6 +251,13 @@ impl KeyPrefix {
             PrefixState::None => {
                 if key.code == KeyCode::Char('g') && key.modifiers.is_empty() {
                     self.state = PrefixState::G;
+                    self.last_time = Some(now);
+                    self.started = true;
+                    None
+                } else if key.code == KeyCode::Char('v')
+                    && (key.modifiers.contains(KeyModifiers::CONTROL) || key.modifiers.is_empty())
+                {
+                    self.state = PrefixState::Sort;
                     self.last_time = Some(now);
                     self.started = true;
                     None
@@ -249,6 +274,19 @@ impl KeyPrefix {
                 self.exited = true;
                 if elapsed <= self.timeout {
                     gmap.get(&key.code).copied()
+                } else {
+                    None
+                }
+            }
+            PrefixState::Sort => {
+                let elapsed = self
+                    .last_time
+                    .map_or(Duration::MAX, |t| now.duration_since(t));
+                self.state = PrefixState::None;
+                self.last_time = None;
+                self.exited = true;
+                if elapsed <= self.timeout {
+                    sortmap.get(&key.code).copied()
                 } else {
                     None
                 }
@@ -270,8 +308,12 @@ impl KeyPrefix {
         self.state == PrefixState::G
     }
 
+    pub(crate) fn is_sort_state(&self) -> bool {
+        self.state == PrefixState::Sort
+    }
+
     pub(crate) fn expired(&self) -> bool {
-        self.state == PrefixState::G
+        (self.state == PrefixState::G || self.state == PrefixState::Sort)
             && self
                 .last_time
                 .is_some_and(|time| time.elapsed() >= self.timeout)

--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -51,6 +51,7 @@ impl NavState {
         entries: &[FileEntry],
         selected_idx => selected: usize,
         shown_indices: &[usize],
+        sort_config: SortConfig,
         sort_column: &Option<Vec<Arc<str>>>,
         markers: &HashSet<PathBuf>,
         filter: &str,
@@ -340,17 +341,9 @@ impl NavState {
         }
     }
 
-    pub(crate) fn sort_config(&self) -> SortConfig {
-        self.sort_config
-    }
-
     pub(crate) fn set_sort_config(&mut self, sort_config: SortConfig) {
         self.sort_config = sort_config;
     }
-
-    // pub(crate) fn reset_sort_config(&mut self) {
-    //     self.sort_config = SortConfig::default();
-    // }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -9,6 +9,7 @@ use crate::core::formatter::format_display_path;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Holds the navigation, selection and file list state of a pane.
 pub(crate) struct NavState {
@@ -21,6 +22,7 @@ pub(crate) struct NavState {
     filter: String,
     filters: HashMap<PathBuf, String>,
     sort_config: SortConfig,
+    sort_column: Option<Vec<Arc<str>>>,
     display_path: String,
     request_id: u64,
 }
@@ -38,6 +40,7 @@ impl NavState {
             filter: String::new(),
             filters: HashMap::new(),
             sort_config: SortConfig::default(),
+            sort_column: None,
             display_path,
             request_id: 0,
         }
@@ -47,6 +50,8 @@ impl NavState {
         current_dir: &Path,
         entries: &[FileEntry],
         selected_idx => selected: usize,
+        shown_indices: &[usize],
+        sort_column: &Option<Vec<Arc<str>>>,
         markers: &HashSet<PathBuf>,
         filter: &str,
         display_path: &str,
@@ -143,11 +148,13 @@ impl NavState {
         &mut self,
         path: PathBuf,
         entries: Vec<FileEntry>,
+        sort_column: Option<Vec<Arc<str>>>,
         focus: Option<OsString>,
     ) {
         self.current_dir = path;
         self.display_path = format_display_path(&self.current_dir);
         self.entries = entries;
+        self.sort_column = sort_column;
 
         self.restore_filter_for_current_dir();
         self.rebuild_shown_cache();
@@ -387,314 +394,313 @@ impl Default for SortConfig {
     }
 }
 
-/// Integration tests for navigation
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use crate::core::browse_dir;
-
-    use rand::rng;
-    use rand::seq::SliceRandom;
-    use std::collections::HashSet;
-    use std::error;
-    use std::fs;
-    use std::fs::File;
-    use std::path::PathBuf;
-    use tempfile::tempdir;
-
-    #[test]
-    fn navstate_rapid_navigation() -> Result<(), Box<dyn error::Error>> {
-        let dir = tempdir()?;
-        let file_count = 10;
-
-        for i in 0..file_count {
-            let file_path = dir.path().join(format!("testfile_{i}.txt"));
-            File::create(&file_path)?;
-        }
-
-        let entries = browse_dir(dir.path())?;
-        assert!(!entries.is_empty(), "sandbox should not be empty");
-
-        let mut nav = NavState::new(dir.path().to_path_buf());
-        nav.update_from_worker(dir.path().to_path_buf(), entries.clone(), None);
-
-        assert_eq!(
-            nav.entries().len(),
-            file_count,
-            "initial entry count mismatch"
-        );
-
-        let down_presses = 1000;
-        for _ in 0..down_presses {
-            assert!(nav.move_down(), "nav.move_down() failed during stress");
-        }
-
-        let expected_idx = down_presses % file_count;
-        assert_eq!(
-            nav.selected_idx(),
-            expected_idx,
-            "wrong index after DOWN stress"
-        );
-
-        let selected = nav.selected_entry().ok_or("no entry selected after DOWN")?;
-        assert_eq!(selected.name_str(), entries[expected_idx].name_str());
-
-        let up_presses = 1000;
-        for _ in 0..up_presses {
-            assert!(nav.move_up(), "nav.move_up() failed during stress");
-        }
-
-        // Mathematical wrap-around check
-        let expected_idx_up = (expected_idx + file_count - (up_presses % file_count)) % file_count;
-        assert_eq!(
-            nav.selected_idx(),
-            expected_idx_up,
-            "wrong index after UP stress"
-        );
-
-        let selected_up = nav.selected_entry().ok_or("no entry selected after UP")?;
-        assert_eq!(selected_up.name_str(), entries[expected_idx_up].name_str());
-
-        // Ensure the internal state hasn't corrupted the entry list
-        for (i, entry) in nav.entries().iter().enumerate() {
-            assert_eq!(
-                entry.name_str(),
-                entries[i].name_str(),
-                "data corruption at index {i}"
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn navstate_navigation() -> Result<(), Box<dyn error::Error>> {
-        let base = tempdir()?;
-        let base_path = base.path().to_path_buf();
-        let subdir_path = base_path.join("subdir");
-        let subsubdir_path = subdir_path.join("subsub");
-
-        fs::create_dir(&subdir_path)?;
-        fs::create_dir(&subsubdir_path)?;
-        File::create(base_path.join("file_base.txt"))?;
-        File::create(subdir_path.join("file_sub.txt"))?;
-        File::create(subsubdir_path.join("file_subsub.txt"))?;
-
-        let base_entries = browse_dir(&base_path)?;
-        let sub_entries = browse_dir(&subdir_path)?;
-        let subsub_entries = browse_dir(&subsubdir_path)?;
-
-        let mut nav = NavState::new(base_path.clone());
-        let repetitions = 500;
-
-        for i in 0..repetitions {
-            nav.set_path(subdir_path.clone());
-            nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-
-            assert_eq!(nav.current_dir(), &subdir_path);
-            assert!(
-                nav.entries().iter().any(|e| e.name() == "subsub"),
-                "Iter {i} missing subsub"
-            );
-
-            let parent_path = nav.current_dir().parent().ok_or("No parent dir")?;
-            assert_eq!(parent_path, base_path, "Iter {i} parent mismatch");
-
-            nav.set_path(subsubdir_path.clone());
-            nav.update_from_worker(subsubdir_path.clone(), subsub_entries.clone(), None);
-
-            assert_eq!(nav.current_dir(), &subsubdir_path);
-            assert!(nav.entries().iter().any(|e| e.name() == "file_subsub.txt"));
-
-            nav.set_path(subdir_path.clone());
-            nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-            assert_eq!(nav.current_dir(), &subdir_path);
-
-            nav.set_path(base_path.clone());
-            nav.update_from_worker(base_path.clone(), base_entries.clone(), None);
-
-            assert_eq!(nav.current_dir(), &base_path);
-            assert!(nav.entries().iter().any(|e| e.name() == "subdir"));
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn navstate_selection_persistence() -> Result<(), Box<dyn error::Error>> {
-        let base = tempdir()?;
-        let base_path = base.path().to_path_buf();
-        let subdir_path = base_path.join("subdir");
-
-        fs::create_dir_all(&subdir_path)?;
-        for i in 0..20 {
-            File::create(subdir_path.join(format!("file_{}.txt", i)))?;
-        }
-
-        let base_entries = browse_dir(&base_path)?;
-        let sub_entries = browse_dir(&subdir_path)?;
-
-        let mut nav = NavState::new(base_path.clone());
-        let repetitions = 200;
-
-        nav.set_path(subdir_path.clone());
-        nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-
-        for _ in 0..5 {
-            nav.move_down();
-        }
-        assert_eq!(nav.selected_idx(), 5, "Initial move failed");
-
-        for i in 0..repetitions {
-            nav.set_path(base_path.clone());
-            nav.update_from_worker(base_path.clone(), base_entries.clone(), None);
-
-            nav.move_down();
-
-            // Return to Subdir
-            nav.set_path(subdir_path.clone());
-            nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-
-            assert_eq!(
-                nav.selected_idx(),
-                5,
-                "Selection lost at iteration {}. Should have stayed at 5.",
-                i
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn navstate_filter_persistence() -> Result<(), Box<dyn error::Error>> {
-        let dir = tempdir()?;
-        let base_path = dir.path().to_path_buf();
-
-        let names = vec![
-            "main.rs",
-            "lib.rs",
-            "cargo.toml",
-            "readme.md",
-            "app.rs",
-            "ui.rs",
-            "file_manager.rs",
-            "config.json",
-            "styles.css",
-        ];
-        for name in &names {
-            fs::write(base_path.join(name), "")?;
-        }
-
-        let mut entries = browse_dir(&base_path)?;
-        entries.shuffle(&mut rng());
-
-        let mut nav = NavState::new(base_path.clone());
-        nav.update_from_worker(base_path.clone(), entries, None);
-
-        let target_name = "file_manager.rs";
-
-        let actual_start_pos = nav
-            .shown_entries()
-            .position(|e| e.name_str() == target_name)
-            .ok_or("Target not found in nav state")?;
-
-        for _ in 0..actual_start_pos {
-            nav.move_down();
-        }
-
-        let selected = nav.selected_entry().ok_or("No entry selected")?;
-        assert_eq!(selected.name_str(), target_name);
-
-        let input_buffer = "file".to_string();
-        nav.set_filter(input_buffer);
-
-        let final_entry = nav.selected_entry().ok_or("Selection lost after filter")?;
-
-        assert_eq!(
-            final_entry.name_str(),
-            target_name,
-            "Selection persistence failed! Found {} instead. Filter was 'file'.",
-            final_entry.name_str()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn navstate_marker_persistence() -> Result<(), Box<dyn error::Error>> {
-        let dir = tempdir()?;
-        let base_path = dir.path().to_path_buf();
-
-        let names = vec!["apple.txt", "banana.txt", "crab.txt"];
-        for name in &names {
-            fs::write(base_path.join(name), "")?;
-        }
-
-        let mut entries = browse_dir(&base_path)?;
-        // Shuffle to ensure we arent relying on alphabetical order
-        entries.shuffle(&mut rng());
-
-        let mut nav = NavState::new(base_path.clone());
-        nav.update_from_worker(base_path.clone(), entries, None);
-
-        let mut clipboard: Option<HashSet<PathBuf>> = None;
-
-        let to_mark = vec!["apple.txt", "banana.txt"];
-        for target in to_mark {
-            // Find it in the current view
-            let pos = nav
-                .shown_entries()
-                .position(|e| e.name_str() == target)
-                .ok_or("target not found")?;
-
-            // Reset to top and move down to simulate real user navigation
-            while nav.selected_idx() > 0 {
-                nav.move_up();
-            }
-            for _ in 0..pos {
-                nav.move_down();
-            }
-
-            let selected = nav.selected_entry().ok_or("No entry selected to mark")?;
-            assert_eq!(selected.name_str(), target);
-            nav.toggle_marker(&mut clipboard);
-        }
-
-        assert_eq!(nav.markers().len(), 2);
-
-        nav.set_filter("crab".to_string());
-
-        assert_eq!(nav.shown_entries_len(), 1);
-        let crab_selected = nav.selected_entry().ok_or("No crab selected")?;
-        assert_eq!(crab_selected.name_str(), "crab.txt");
-
-        let targets = nav.get_action_targets();
-        assert_eq!(
-            targets.len(),
-            2,
-            "Should target 2 marked files even if hidden"
-        );
-        assert!(targets.contains(&base_path.join("apple.txt")));
-        assert!(targets.contains(&base_path.join("banana.txt")));
-        assert!(
-            !targets.contains(&base_path.join("cherry.txt")),
-            "Should ignore selection when markers exist"
-        );
-
-        nav.clear_filters();
-        // Navigate to apple.txt
-        let apple_pos = nav
-            .shown_entries()
-            .position(|e| e.name_str() == "apple.txt")
-            .ok_or("Apple not found")?;
-        while nav.selected_idx() < apple_pos {
-            nav.move_down();
-        }
-        while nav.selected_idx() > apple_pos {
-            nav.move_up();
-        }
-
-        nav.toggle_marker(&mut clipboard);
-        assert_eq!(nav.markers().len(), 1);
-        assert!(nav.markers().contains(&base_path.join("banana.txt")));
-        Ok(())
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//
+//     use crate::core::browse_dir;
+//
+//     use rand::rng;
+//     use rand::seq::SliceRandom;
+//     use std::collections::HashSet;
+//     use std::error;
+//     use std::fs;
+//     use std::fs::File;
+//     use std::path::PathBuf;
+//     use tempfile::tempdir;
+//
+//     #[test]
+//     fn navstate_rapid_navigation() -> Result<(), Box<dyn error::Error>> {
+//         let dir = tempdir()?;
+//         let file_count = 10;
+//
+//         for i in 0..file_count {
+//             let file_path = dir.path().join(format!("testfile_{i}.txt"));
+//             File::create(&file_path)?;
+//         }
+//
+//         let entries = browse_dir(dir.path())?;
+//         assert!(!entries.is_empty(), "sandbox should not be empty");
+//
+//         let mut nav = NavState::new(dir.path().to_path_buf());
+//         nav.update_from_worker(dir.path().to_path_buf(), entries.clone(), None);
+//
+//         assert_eq!(
+//             nav.entries().len(),
+//             file_count,
+//             "initial entry count mismatch"
+//         );
+//
+//         let down_presses = 1000;
+//         for _ in 0..down_presses {
+//             assert!(nav.move_down(), "nav.move_down() failed during stress");
+//         }
+//
+//         let expected_idx = down_presses % file_count;
+//         assert_eq!(
+//             nav.selected_idx(),
+//             expected_idx,
+//             "wrong index after DOWN stress"
+//         );
+//
+//         let selected = nav.selected_entry().ok_or("no entry selected after DOWN")?;
+//         assert_eq!(selected.name_str(), entries[expected_idx].name_str());
+//
+//         let up_presses = 1000;
+//         for _ in 0..up_presses {
+//             assert!(nav.move_up(), "nav.move_up() failed during stress");
+//         }
+//
+//         // Mathematical wrap-around check
+//         let expected_idx_up = (expected_idx + file_count - (up_presses % file_count)) % file_count;
+//         assert_eq!(
+//             nav.selected_idx(),
+//             expected_idx_up,
+//             "wrong index after UP stress"
+//         );
+//
+//         let selected_up = nav.selected_entry().ok_or("no entry selected after UP")?;
+//         assert_eq!(selected_up.name_str(), entries[expected_idx_up].name_str());
+//
+//         // Ensure the internal state hasn't corrupted the entry list
+//         for (i, entry) in nav.entries().iter().enumerate() {
+//             assert_eq!(
+//                 entry.name_str(),
+//                 entries[i].name_str(),
+//                 "data corruption at index {i}"
+//             );
+//         }
+//         Ok(())
+//     }
+//
+//     #[test]
+//     fn navstate_navigation() -> Result<(), Box<dyn error::Error>> {
+//         let base = tempdir()?;
+//         let base_path = base.path().to_path_buf();
+//         let subdir_path = base_path.join("subdir");
+//         let subsubdir_path = subdir_path.join("subsub");
+//
+//         fs::create_dir(&subdir_path)?;
+//         fs::create_dir(&subsubdir_path)?;
+//         File::create(base_path.join("file_base.txt"))?;
+//         File::create(subdir_path.join("file_sub.txt"))?;
+//         File::create(subsubdir_path.join("file_subsub.txt"))?;
+//
+//         let base_entries = browse_dir(&base_path)?;
+//         let sub_entries = browse_dir(&subdir_path)?;
+//         let subsub_entries = browse_dir(&subsubdir_path)?;
+//
+//         let mut nav = NavState::new(base_path.clone());
+//         let repetitions = 500;
+//
+//         for i in 0..repetitions {
+//             nav.set_path(subdir_path.clone());
+//             nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
+//
+//             assert_eq!(nav.current_dir(), &subdir_path);
+//             assert!(
+//                 nav.entries().iter().any(|e| e.name() == "subsub"),
+//                 "Iter {i} missing subsub"
+//             );
+//
+//             let parent_path = nav.current_dir().parent().ok_or("No parent dir")?;
+//             assert_eq!(parent_path, base_path, "Iter {i} parent mismatch");
+//
+//             nav.set_path(subsubdir_path.clone());
+//             nav.update_from_worker(subsubdir_path.clone(), subsub_entries.clone(), None);
+//
+//             assert_eq!(nav.current_dir(), &subsubdir_path);
+//             assert!(nav.entries().iter().any(|e| e.name() == "file_subsub.txt"));
+//
+//             nav.set_path(subdir_path.clone());
+//             nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
+//             assert_eq!(nav.current_dir(), &subdir_path);
+//
+//             nav.set_path(base_path.clone());
+//             nav.update_from_worker(base_path.clone(), base_entries.clone(), None);
+//
+//             assert_eq!(nav.current_dir(), &base_path);
+//             assert!(nav.entries().iter().any(|e| e.name() == "subdir"));
+//         }
+//         Ok(())
+//     }
+//
+//     #[test]
+//     fn navstate_selection_persistence() -> Result<(), Box<dyn error::Error>> {
+//         let base = tempdir()?;
+//         let base_path = base.path().to_path_buf();
+//         let subdir_path = base_path.join("subdir");
+//
+//         fs::create_dir_all(&subdir_path)?;
+//         for i in 0..20 {
+//             File::create(subdir_path.join(format!("file_{}.txt", i)))?;
+//         }
+//
+//         let base_entries = browse_dir(&base_path)?;
+//         let sub_entries = browse_dir(&subdir_path)?;
+//
+//         let mut nav = NavState::new(base_path.clone());
+//         let repetitions = 200;
+//
+//         nav.set_path(subdir_path.clone());
+//         nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
+//
+//         for _ in 0..5 {
+//             nav.move_down();
+//         }
+//         assert_eq!(nav.selected_idx(), 5, "Initial move failed");
+//
+//         for i in 0..repetitions {
+//             nav.set_path(base_path.clone());
+//             nav.update_from_worker(base_path.clone(), base_entries.clone(), None);
+//
+//             nav.move_down();
+//
+//             // Return to Subdir
+//             nav.set_path(subdir_path.clone());
+//             nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
+//
+//             assert_eq!(
+//                 nav.selected_idx(),
+//                 5,
+//                 "Selection lost at iteration {}. Should have stayed at 5.",
+//                 i
+//             );
+//         }
+//         Ok(())
+//     }
+//
+//     #[test]
+//     fn navstate_filter_persistence() -> Result<(), Box<dyn error::Error>> {
+//         let dir = tempdir()?;
+//         let base_path = dir.path().to_path_buf();
+//
+//         let names = vec![
+//             "main.rs",
+//             "lib.rs",
+//             "cargo.toml",
+//             "readme.md",
+//             "app.rs",
+//             "ui.rs",
+//             "file_manager.rs",
+//             "config.json",
+//             "styles.css",
+//         ];
+//         for name in &names {
+//             fs::write(base_path.join(name), "")?;
+//         }
+//
+//         let mut entries = browse_dir(&base_path)?;
+//         entries.shuffle(&mut rng());
+//
+//         let mut nav = NavState::new(base_path.clone());
+//         nav.update_from_worker(base_path.clone(), entries, None);
+//
+//         let target_name = "file_manager.rs";
+//
+//         let actual_start_pos = nav
+//             .shown_entries()
+//             .position(|e| e.name_str() == target_name)
+//             .ok_or("Target not found in nav state")?;
+//
+//         for _ in 0..actual_start_pos {
+//             nav.move_down();
+//         }
+//
+//         let selected = nav.selected_entry().ok_or("No entry selected")?;
+//         assert_eq!(selected.name_str(), target_name);
+//
+//         let input_buffer = "file".to_string();
+//         nav.set_filter(input_buffer);
+//
+//         let final_entry = nav.selected_entry().ok_or("Selection lost after filter")?;
+//
+//         assert_eq!(
+//             final_entry.name_str(),
+//             target_name,
+//             "Selection persistence failed! Found {} instead. Filter was 'file'.",
+//             final_entry.name_str()
+//         );
+//         Ok(())
+//     }
+//
+//     #[test]
+//     fn navstate_marker_persistence() -> Result<(), Box<dyn error::Error>> {
+//         let dir = tempdir()?;
+//         let base_path = dir.path().to_path_buf();
+//
+//         let names = vec!["apple.txt", "banana.txt", "crab.txt"];
+//         for name in &names {
+//             fs::write(base_path.join(name), "")?;
+//         }
+//
+//         let mut entries = browse_dir(&base_path)?;
+//         // Shuffle to ensure we arent relying on alphabetical order
+//         entries.shuffle(&mut rng());
+//
+//         let mut nav = NavState::new(base_path.clone());
+//         nav.update_from_worker(base_path.clone(), entries, None);
+//
+//         let mut clipboard: Option<HashSet<PathBuf>> = None;
+//
+//         let to_mark = vec!["apple.txt", "banana.txt"];
+//         for target in to_mark {
+//             // Find it in the current view
+//             let pos = nav
+//                 .shown_entries()
+//                 .position(|e| e.name_str() == target)
+//                 .ok_or("target not found")?;
+//
+//             // Reset to top and move down to simulate real user navigation
+//             while nav.selected_idx() > 0 {
+//                 nav.move_up();
+//             }
+//             for _ in 0..pos {
+//                 nav.move_down();
+//             }
+//
+//             let selected = nav.selected_entry().ok_or("No entry selected to mark")?;
+//             assert_eq!(selected.name_str(), target);
+//             nav.toggle_marker(&mut clipboard);
+//         }
+//
+//         assert_eq!(nav.markers().len(), 2);
+//
+//         nav.set_filter("crab".to_string());
+//
+//         assert_eq!(nav.shown_entries_len(), 1);
+//         let crab_selected = nav.selected_entry().ok_or("No crab selected")?;
+//         assert_eq!(crab_selected.name_str(), "crab.txt");
+//
+//         let targets = nav.get_action_targets();
+//         assert_eq!(
+//             targets.len(),
+//             2,
+//             "Should target 2 marked files even if hidden"
+//         );
+//         assert!(targets.contains(&base_path.join("apple.txt")));
+//         assert!(targets.contains(&base_path.join("banana.txt")));
+//         assert!(
+//             !targets.contains(&base_path.join("cherry.txt")),
+//             "Should ignore selection when markers exist"
+//         );
+//
+//         nav.clear_filters();
+//         // Navigate to apple.txt
+//         let apple_pos = nav
+//             .shown_entries()
+//             .position(|e| e.name_str() == "apple.txt")
+//             .ok_or("Apple not found")?;
+//         while nav.selected_idx() < apple_pos {
+//             nav.move_down();
+//         }
+//         while nav.selected_idx() > apple_pos {
+//             nav.move_up();
+//         }
+//
+//         nav.toggle_marker(&mut clipboard);
+//         assert_eq!(nav.markers().len(), 1);
+//         assert!(nav.markers().contains(&base_path.join("banana.txt")));
+//         Ok(())
+//     }
+// }

--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -394,313 +394,313 @@ impl Default for SortConfig {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//
-//     use crate::core::browse_dir;
-//
-//     use rand::rng;
-//     use rand::seq::SliceRandom;
-//     use std::collections::HashSet;
-//     use std::error;
-//     use std::fs;
-//     use std::fs::File;
-//     use std::path::PathBuf;
-//     use tempfile::tempdir;
-//
-//     #[test]
-//     fn navstate_rapid_navigation() -> Result<(), Box<dyn error::Error>> {
-//         let dir = tempdir()?;
-//         let file_count = 10;
-//
-//         for i in 0..file_count {
-//             let file_path = dir.path().join(format!("testfile_{i}.txt"));
-//             File::create(&file_path)?;
-//         }
-//
-//         let entries = browse_dir(dir.path())?;
-//         assert!(!entries.is_empty(), "sandbox should not be empty");
-//
-//         let mut nav = NavState::new(dir.path().to_path_buf());
-//         nav.update_from_worker(dir.path().to_path_buf(), entries.clone(), None);
-//
-//         assert_eq!(
-//             nav.entries().len(),
-//             file_count,
-//             "initial entry count mismatch"
-//         );
-//
-//         let down_presses = 1000;
-//         for _ in 0..down_presses {
-//             assert!(nav.move_down(), "nav.move_down() failed during stress");
-//         }
-//
-//         let expected_idx = down_presses % file_count;
-//         assert_eq!(
-//             nav.selected_idx(),
-//             expected_idx,
-//             "wrong index after DOWN stress"
-//         );
-//
-//         let selected = nav.selected_entry().ok_or("no entry selected after DOWN")?;
-//         assert_eq!(selected.name_str(), entries[expected_idx].name_str());
-//
-//         let up_presses = 1000;
-//         for _ in 0..up_presses {
-//             assert!(nav.move_up(), "nav.move_up() failed during stress");
-//         }
-//
-//         // Mathematical wrap-around check
-//         let expected_idx_up = (expected_idx + file_count - (up_presses % file_count)) % file_count;
-//         assert_eq!(
-//             nav.selected_idx(),
-//             expected_idx_up,
-//             "wrong index after UP stress"
-//         );
-//
-//         let selected_up = nav.selected_entry().ok_or("no entry selected after UP")?;
-//         assert_eq!(selected_up.name_str(), entries[expected_idx_up].name_str());
-//
-//         // Ensure the internal state hasn't corrupted the entry list
-//         for (i, entry) in nav.entries().iter().enumerate() {
-//             assert_eq!(
-//                 entry.name_str(),
-//                 entries[i].name_str(),
-//                 "data corruption at index {i}"
-//             );
-//         }
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn navstate_navigation() -> Result<(), Box<dyn error::Error>> {
-//         let base = tempdir()?;
-//         let base_path = base.path().to_path_buf();
-//         let subdir_path = base_path.join("subdir");
-//         let subsubdir_path = subdir_path.join("subsub");
-//
-//         fs::create_dir(&subdir_path)?;
-//         fs::create_dir(&subsubdir_path)?;
-//         File::create(base_path.join("file_base.txt"))?;
-//         File::create(subdir_path.join("file_sub.txt"))?;
-//         File::create(subsubdir_path.join("file_subsub.txt"))?;
-//
-//         let base_entries = browse_dir(&base_path)?;
-//         let sub_entries = browse_dir(&subdir_path)?;
-//         let subsub_entries = browse_dir(&subsubdir_path)?;
-//
-//         let mut nav = NavState::new(base_path.clone());
-//         let repetitions = 500;
-//
-//         for i in 0..repetitions {
-//             nav.set_path(subdir_path.clone());
-//             nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-//
-//             assert_eq!(nav.current_dir(), &subdir_path);
-//             assert!(
-//                 nav.entries().iter().any(|e| e.name() == "subsub"),
-//                 "Iter {i} missing subsub"
-//             );
-//
-//             let parent_path = nav.current_dir().parent().ok_or("No parent dir")?;
-//             assert_eq!(parent_path, base_path, "Iter {i} parent mismatch");
-//
-//             nav.set_path(subsubdir_path.clone());
-//             nav.update_from_worker(subsubdir_path.clone(), subsub_entries.clone(), None);
-//
-//             assert_eq!(nav.current_dir(), &subsubdir_path);
-//             assert!(nav.entries().iter().any(|e| e.name() == "file_subsub.txt"));
-//
-//             nav.set_path(subdir_path.clone());
-//             nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-//             assert_eq!(nav.current_dir(), &subdir_path);
-//
-//             nav.set_path(base_path.clone());
-//             nav.update_from_worker(base_path.clone(), base_entries.clone(), None);
-//
-//             assert_eq!(nav.current_dir(), &base_path);
-//             assert!(nav.entries().iter().any(|e| e.name() == "subdir"));
-//         }
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn navstate_selection_persistence() -> Result<(), Box<dyn error::Error>> {
-//         let base = tempdir()?;
-//         let base_path = base.path().to_path_buf();
-//         let subdir_path = base_path.join("subdir");
-//
-//         fs::create_dir_all(&subdir_path)?;
-//         for i in 0..20 {
-//             File::create(subdir_path.join(format!("file_{}.txt", i)))?;
-//         }
-//
-//         let base_entries = browse_dir(&base_path)?;
-//         let sub_entries = browse_dir(&subdir_path)?;
-//
-//         let mut nav = NavState::new(base_path.clone());
-//         let repetitions = 200;
-//
-//         nav.set_path(subdir_path.clone());
-//         nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-//
-//         for _ in 0..5 {
-//             nav.move_down();
-//         }
-//         assert_eq!(nav.selected_idx(), 5, "Initial move failed");
-//
-//         for i in 0..repetitions {
-//             nav.set_path(base_path.clone());
-//             nav.update_from_worker(base_path.clone(), base_entries.clone(), None);
-//
-//             nav.move_down();
-//
-//             // Return to Subdir
-//             nav.set_path(subdir_path.clone());
-//             nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None);
-//
-//             assert_eq!(
-//                 nav.selected_idx(),
-//                 5,
-//                 "Selection lost at iteration {}. Should have stayed at 5.",
-//                 i
-//             );
-//         }
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn navstate_filter_persistence() -> Result<(), Box<dyn error::Error>> {
-//         let dir = tempdir()?;
-//         let base_path = dir.path().to_path_buf();
-//
-//         let names = vec![
-//             "main.rs",
-//             "lib.rs",
-//             "cargo.toml",
-//             "readme.md",
-//             "app.rs",
-//             "ui.rs",
-//             "file_manager.rs",
-//             "config.json",
-//             "styles.css",
-//         ];
-//         for name in &names {
-//             fs::write(base_path.join(name), "")?;
-//         }
-//
-//         let mut entries = browse_dir(&base_path)?;
-//         entries.shuffle(&mut rng());
-//
-//         let mut nav = NavState::new(base_path.clone());
-//         nav.update_from_worker(base_path.clone(), entries, None);
-//
-//         let target_name = "file_manager.rs";
-//
-//         let actual_start_pos = nav
-//             .shown_entries()
-//             .position(|e| e.name_str() == target_name)
-//             .ok_or("Target not found in nav state")?;
-//
-//         for _ in 0..actual_start_pos {
-//             nav.move_down();
-//         }
-//
-//         let selected = nav.selected_entry().ok_or("No entry selected")?;
-//         assert_eq!(selected.name_str(), target_name);
-//
-//         let input_buffer = "file".to_string();
-//         nav.set_filter(input_buffer);
-//
-//         let final_entry = nav.selected_entry().ok_or("Selection lost after filter")?;
-//
-//         assert_eq!(
-//             final_entry.name_str(),
-//             target_name,
-//             "Selection persistence failed! Found {} instead. Filter was 'file'.",
-//             final_entry.name_str()
-//         );
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn navstate_marker_persistence() -> Result<(), Box<dyn error::Error>> {
-//         let dir = tempdir()?;
-//         let base_path = dir.path().to_path_buf();
-//
-//         let names = vec!["apple.txt", "banana.txt", "crab.txt"];
-//         for name in &names {
-//             fs::write(base_path.join(name), "")?;
-//         }
-//
-//         let mut entries = browse_dir(&base_path)?;
-//         // Shuffle to ensure we arent relying on alphabetical order
-//         entries.shuffle(&mut rng());
-//
-//         let mut nav = NavState::new(base_path.clone());
-//         nav.update_from_worker(base_path.clone(), entries, None);
-//
-//         let mut clipboard: Option<HashSet<PathBuf>> = None;
-//
-//         let to_mark = vec!["apple.txt", "banana.txt"];
-//         for target in to_mark {
-//             // Find it in the current view
-//             let pos = nav
-//                 .shown_entries()
-//                 .position(|e| e.name_str() == target)
-//                 .ok_or("target not found")?;
-//
-//             // Reset to top and move down to simulate real user navigation
-//             while nav.selected_idx() > 0 {
-//                 nav.move_up();
-//             }
-//             for _ in 0..pos {
-//                 nav.move_down();
-//             }
-//
-//             let selected = nav.selected_entry().ok_or("No entry selected to mark")?;
-//             assert_eq!(selected.name_str(), target);
-//             nav.toggle_marker(&mut clipboard);
-//         }
-//
-//         assert_eq!(nav.markers().len(), 2);
-//
-//         nav.set_filter("crab".to_string());
-//
-//         assert_eq!(nav.shown_entries_len(), 1);
-//         let crab_selected = nav.selected_entry().ok_or("No crab selected")?;
-//         assert_eq!(crab_selected.name_str(), "crab.txt");
-//
-//         let targets = nav.get_action_targets();
-//         assert_eq!(
-//             targets.len(),
-//             2,
-//             "Should target 2 marked files even if hidden"
-//         );
-//         assert!(targets.contains(&base_path.join("apple.txt")));
-//         assert!(targets.contains(&base_path.join("banana.txt")));
-//         assert!(
-//             !targets.contains(&base_path.join("cherry.txt")),
-//             "Should ignore selection when markers exist"
-//         );
-//
-//         nav.clear_filters();
-//         // Navigate to apple.txt
-//         let apple_pos = nav
-//             .shown_entries()
-//             .position(|e| e.name_str() == "apple.txt")
-//             .ok_or("Apple not found")?;
-//         while nav.selected_idx() < apple_pos {
-//             nav.move_down();
-//         }
-//         while nav.selected_idx() > apple_pos {
-//             nav.move_up();
-//         }
-//
-//         nav.toggle_marker(&mut clipboard);
-//         assert_eq!(nav.markers().len(), 1);
-//         assert!(nav.markers().contains(&base_path.join("banana.txt")));
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::core::browse_dir;
+
+    use rand::rng;
+    use rand::seq::SliceRandom;
+    use std::collections::HashSet;
+    use std::error;
+    use std::fs;
+    use std::fs::File;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn navstate_rapid_navigation() -> Result<(), Box<dyn error::Error>> {
+        let dir = tempdir()?;
+        let file_count = 10;
+
+        for i in 0..file_count {
+            let file_path = dir.path().join(format!("testfile_{i}.txt"));
+            File::create(&file_path)?;
+        }
+
+        let entries = browse_dir(dir.path())?;
+        assert!(!entries.is_empty(), "sandbox should not be empty");
+
+        let mut nav = NavState::new(dir.path().to_path_buf());
+        nav.update_from_worker(dir.path().to_path_buf(), entries.clone(), None, None);
+
+        assert_eq!(
+            nav.entries().len(),
+            file_count,
+            "initial entry count mismatch"
+        );
+
+        let down_presses = 1000;
+        for _ in 0..down_presses {
+            assert!(nav.move_down(), "nav.move_down() failed during stress");
+        }
+
+        let expected_idx = down_presses % file_count;
+        assert_eq!(
+            nav.selected_idx(),
+            expected_idx,
+            "wrong index after DOWN stress"
+        );
+
+        let selected = nav.selected_entry().ok_or("no entry selected after DOWN")?;
+        assert_eq!(selected.name_str(), entries[expected_idx].name_str());
+
+        let up_presses = 1000;
+        for _ in 0..up_presses {
+            assert!(nav.move_up(), "nav.move_up() failed during stress");
+        }
+
+        // Mathematical wrap-around check
+        let expected_idx_up = (expected_idx + file_count - (up_presses % file_count)) % file_count;
+        assert_eq!(
+            nav.selected_idx(),
+            expected_idx_up,
+            "wrong index after UP stress"
+        );
+
+        let selected_up = nav.selected_entry().ok_or("no entry selected after UP")?;
+        assert_eq!(selected_up.name_str(), entries[expected_idx_up].name_str());
+
+        // Ensure the internal state hasn't corrupted the entry list
+        for (i, entry) in nav.entries().iter().enumerate() {
+            assert_eq!(
+                entry.name_str(),
+                entries[i].name_str(),
+                "data corruption at index {i}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn navstate_navigation() -> Result<(), Box<dyn error::Error>> {
+        let base = tempdir()?;
+        let base_path = base.path().to_path_buf();
+        let subdir_path = base_path.join("subdir");
+        let subsubdir_path = subdir_path.join("subsub");
+
+        fs::create_dir(&subdir_path)?;
+        fs::create_dir(&subsubdir_path)?;
+        File::create(base_path.join("file_base.txt"))?;
+        File::create(subdir_path.join("file_sub.txt"))?;
+        File::create(subsubdir_path.join("file_subsub.txt"))?;
+
+        let base_entries = browse_dir(&base_path)?;
+        let sub_entries = browse_dir(&subdir_path)?;
+        let subsub_entries = browse_dir(&subsubdir_path)?;
+
+        let mut nav = NavState::new(base_path.clone());
+        let repetitions = 500;
+
+        for i in 0..repetitions {
+            nav.set_path(subdir_path.clone());
+            nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None, None);
+
+            assert_eq!(nav.current_dir(), &subdir_path);
+            assert!(
+                nav.entries().iter().any(|e| e.name() == "subsub"),
+                "Iter {i} missing subsub"
+            );
+
+            let parent_path = nav.current_dir().parent().ok_or("No parent dir")?;
+            assert_eq!(parent_path, base_path, "Iter {i} parent mismatch");
+
+            nav.set_path(subsubdir_path.clone());
+            nav.update_from_worker(subsubdir_path.clone(), subsub_entries.clone(), None, None);
+
+            assert_eq!(nav.current_dir(), &subsubdir_path);
+            assert!(nav.entries().iter().any(|e| e.name() == "file_subsub.txt"));
+
+            nav.set_path(subdir_path.clone());
+            nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None, None);
+            assert_eq!(nav.current_dir(), &subdir_path);
+
+            nav.set_path(base_path.clone());
+            nav.update_from_worker(base_path.clone(), base_entries.clone(), None, None);
+
+            assert_eq!(nav.current_dir(), &base_path);
+            assert!(nav.entries().iter().any(|e| e.name() == "subdir"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn navstate_selection_persistence() -> Result<(), Box<dyn error::Error>> {
+        let base = tempdir()?;
+        let base_path = base.path().to_path_buf();
+        let subdir_path = base_path.join("subdir");
+
+        fs::create_dir_all(&subdir_path)?;
+        for i in 0..20 {
+            File::create(subdir_path.join(format!("file_{}.txt", i)))?;
+        }
+
+        let base_entries = browse_dir(&base_path)?;
+        let sub_entries = browse_dir(&subdir_path)?;
+
+        let mut nav = NavState::new(base_path.clone());
+        let repetitions = 200;
+
+        nav.set_path(subdir_path.clone());
+        nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None, None);
+
+        for _ in 0..5 {
+            nav.move_down();
+        }
+        assert_eq!(nav.selected_idx(), 5, "Initial move failed");
+
+        for i in 0..repetitions {
+            nav.set_path(base_path.clone());
+            nav.update_from_worker(base_path.clone(), base_entries.clone(), None, None);
+
+            nav.move_down();
+
+            // Return to Subdir
+            nav.set_path(subdir_path.clone());
+            nav.update_from_worker(subdir_path.clone(), sub_entries.clone(), None, None);
+
+            assert_eq!(
+                nav.selected_idx(),
+                5,
+                "Selection lost at iteration {}. Should have stayed at 5.",
+                i
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn navstate_filter_persistence() -> Result<(), Box<dyn error::Error>> {
+        let dir = tempdir()?;
+        let base_path = dir.path().to_path_buf();
+
+        let names = vec![
+            "main.rs",
+            "lib.rs",
+            "cargo.toml",
+            "readme.md",
+            "app.rs",
+            "ui.rs",
+            "file_manager.rs",
+            "config.json",
+            "styles.css",
+        ];
+        for name in &names {
+            fs::write(base_path.join(name), "")?;
+        }
+
+        let mut entries = browse_dir(&base_path)?;
+        entries.shuffle(&mut rng());
+
+        let mut nav = NavState::new(base_path.clone());
+        nav.update_from_worker(base_path.clone(), entries, None, None);
+
+        let target_name = "file_manager.rs";
+
+        let actual_start_pos = nav
+            .shown_entries()
+            .position(|e| e.name_str() == target_name)
+            .ok_or("Target not found in nav state")?;
+
+        for _ in 0..actual_start_pos {
+            nav.move_down();
+        }
+
+        let selected = nav.selected_entry().ok_or("No entry selected")?;
+        assert_eq!(selected.name_str(), target_name);
+
+        let input_buffer = "file".to_string();
+        nav.set_filter(input_buffer);
+
+        let final_entry = nav.selected_entry().ok_or("Selection lost after filter")?;
+
+        assert_eq!(
+            final_entry.name_str(),
+            target_name,
+            "Selection persistence failed! Found {} instead. Filter was 'file'.",
+            final_entry.name_str()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn navstate_marker_persistence() -> Result<(), Box<dyn error::Error>> {
+        let dir = tempdir()?;
+        let base_path = dir.path().to_path_buf();
+
+        let names = vec!["apple.txt", "banana.txt", "crab.txt"];
+        for name in &names {
+            fs::write(base_path.join(name), "")?;
+        }
+
+        let mut entries = browse_dir(&base_path)?;
+        // Shuffle to ensure we arent relying on alphabetical order
+        entries.shuffle(&mut rng());
+
+        let mut nav = NavState::new(base_path.clone());
+        nav.update_from_worker(base_path.clone(), entries, None, None);
+
+        let mut clipboard: Option<HashSet<PathBuf>> = None;
+
+        let to_mark = vec!["apple.txt", "banana.txt"];
+        for target in to_mark {
+            // Find it in the current view
+            let pos = nav
+                .shown_entries()
+                .position(|e| e.name_str() == target)
+                .ok_or("target not found")?;
+
+            // Reset to top and move down to simulate real user navigation
+            while nav.selected_idx() > 0 {
+                nav.move_up();
+            }
+            for _ in 0..pos {
+                nav.move_down();
+            }
+
+            let selected = nav.selected_entry().ok_or("No entry selected to mark")?;
+            assert_eq!(selected.name_str(), target);
+            nav.toggle_marker(&mut clipboard);
+        }
+
+        assert_eq!(nav.markers().len(), 2);
+
+        nav.set_filter("crab".to_string());
+
+        assert_eq!(nav.shown_entries_len(), 1);
+        let crab_selected = nav.selected_entry().ok_or("No crab selected")?;
+        assert_eq!(crab_selected.name_str(), "crab.txt");
+
+        let targets = nav.get_action_targets();
+        assert_eq!(
+            targets.len(),
+            2,
+            "Should target 2 marked files even if hidden"
+        );
+        assert!(targets.contains(&base_path.join("apple.txt")));
+        assert!(targets.contains(&base_path.join("banana.txt")));
+        assert!(
+            !targets.contains(&base_path.join("cherry.txt")),
+            "Should ignore selection when markers exist"
+        );
+
+        nav.clear_filters();
+        // Navigate to apple.txt
+        let apple_pos = nav
+            .shown_entries()
+            .position(|e| e.name_str() == "apple.txt")
+            .ok_or("Apple not found")?;
+        while nav.selected_idx() < apple_pos {
+            nav.move_down();
+        }
+        while nav.selected_idx() > apple_pos {
+            nav.move_up();
+        }
+
+        nav.toggle_marker(&mut clipboard);
+        assert_eq!(nav.markers().len(), 1);
+        assert!(nav.markers().contains(&base_path.join("banana.txt")));
+        Ok(())
+    }
+}

--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -372,7 +372,7 @@ impl SortOrder {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct SortConfig {
     pub(crate) mode: SortMode,
     pub(crate) order: SortOrder,

--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -20,6 +20,7 @@ pub(crate) struct NavState {
     markers: HashSet<PathBuf>,
     filter: String,
     filters: HashMap<PathBuf, String>,
+    sort_config: SortConfig,
     display_path: String,
     request_id: u64,
 }
@@ -36,6 +37,7 @@ impl NavState {
             markers: HashSet::new(),
             filter: String::new(),
             filters: HashMap::new(),
+            sort_config: SortConfig::default(),
             display_path,
             request_id: 0,
         }
@@ -328,6 +330,59 @@ impl NavState {
         let len = self.shown_indices.len();
         if self.selected >= len {
             self.selected = len.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn sort_config(&self) -> SortConfig {
+        self.sort_config
+    }
+
+    pub(crate) fn set_sort_config(&mut self, sort_config: SortConfig) {
+        self.sort_config = sort_config;
+    }
+
+    // pub(crate) fn reset_sort_config(&mut self) {
+    //     self.sort_config = SortConfig::default();
+    // }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SortMode {
+    Name,
+    Modified,
+    Created,
+    Accessed,
+    Size,
+    Extension,
+    Natural,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl SortOrder {
+    pub(crate) fn toggle(self) -> Self {
+        match self {
+            SortOrder::Ascending => SortOrder::Descending,
+            SortOrder::Descending => SortOrder::Ascending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SortConfig {
+    pub(crate) mode: SortMode,
+    pub(crate) order: SortOrder,
+}
+
+impl Default for SortConfig {
+    fn default() -> Self {
+        Self {
+            mode: SortMode::Natural,
+            order: SortOrder::Ascending,
         }
     }
 }

--- a/src/app/parent.rs
+++ b/src/app/parent.rs
@@ -3,6 +3,7 @@
 //! Tracks entries, selection, worker requests for the parent pane view above the current working
 //! directory
 
+use crate::app::nav::SortConfig;
 use crate::core::FileEntry;
 use std::path::{Path, PathBuf};
 
@@ -15,6 +16,7 @@ pub(crate) struct ParentState {
     entries: Vec<FileEntry>,
     selected_idx: Option<usize>,
     last_path: Option<PathBuf>,
+    last_sort: Option<SortConfig>,
     request_id: u64,
 }
 
@@ -30,13 +32,18 @@ impl ParentState {
     }
 
     #[inline]
-    pub(super) fn is_cached(&self, parent_path: &Path) -> bool {
-        matches!(self.last_path(), Some(last) if last == parent_path && !self.entries().is_empty())
+    pub(super) fn is_cached(&self, parent_path: &Path, sort: SortConfig) -> bool {
+        matches!(
+            self.last_path(),
+            Some(last) if last == parent_path
+        ) && self.last_sort == Some(sort)
+            && !self.entries.is_empty()
     }
 
-    pub(super) fn prepare_new_request(&mut self, path: &Path) -> u64 {
+    pub(super) fn prepare_new_request(&mut self, path: &Path, sort: SortConfig) -> u64 {
         self.request_id = self.request_id.wrapping_add(1);
         self.last_path = Some(path.to_path_buf());
+        self.last_sort = Some(sort);
         self.request_id
     }
 
@@ -49,6 +56,7 @@ impl ParentState {
         current_name: &str,
         req_id: u64,
         parent_path: &Path,
+        sort: SortConfig,
     ) {
         if req_id < self.request_id {
             return;
@@ -57,6 +65,7 @@ impl ParentState {
         self.selected_idx = entries.iter().position(|e| e.name_str() == current_name);
         self.entries = entries;
         self.last_path = Some(parent_path.to_path_buf());
+        self.last_sort = Some(sort);
         self.request_id = req_id;
     }
 
@@ -66,6 +75,7 @@ impl ParentState {
         self.entries.clear();
         self.selected_idx = None;
         self.last_path = None;
+        self.last_sort = None;
         self.request_id = self.request_id.wrapping_add(1);
     }
 }

--- a/src/app/parent.rs
+++ b/src/app/parent.rs
@@ -6,6 +6,7 @@
 use crate::app::nav::SortConfig;
 use crate::core::FileEntry;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Holds the state of the parent directory pane
 ///
@@ -14,6 +15,7 @@ use std::path::{Path, PathBuf};
 #[derive(Default)]
 pub(crate) struct ParentState {
     entries: Vec<FileEntry>,
+    sort_column: Option<Vec<Arc<str>>>,
     selected_idx: Option<usize>,
     last_path: Option<PathBuf>,
     last_sort: Option<SortConfig>,
@@ -24,6 +26,7 @@ impl ParentState {
     crate::getters! {
         request_id: u64,
         entries: &[FileEntry],
+        sort_column: &Option<Vec<Arc<str>>>,
         selected_idx: Option<usize>,
     }
 
@@ -57,6 +60,7 @@ impl ParentState {
         req_id: u64,
         parent_path: &Path,
         sort: SortConfig,
+        sort_column: Option<Vec<Arc<str>>>,
     ) {
         if req_id < self.request_id {
             return;
@@ -66,6 +70,7 @@ impl ParentState {
         self.entries = entries;
         self.last_path = Some(parent_path.to_path_buf());
         self.last_sort = Some(sort);
+        self.sort_column = sort_column;
         self.request_id = req_id;
     }
 

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -7,6 +7,7 @@ use crate::core::FileEntry;
 use ansi_to_tui::IntoText;
 use ratatui::text::Text;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 /// Preview content for the preview pane
@@ -14,7 +15,10 @@ use std::time::Instant;
 /// Holds loaded lines for file preview, directory entries for folder preview or empty if nothing.
 /// Used to display or render file/folder content in the preview pane
 pub(crate) enum PreviewData {
-    Directory(Vec<FileEntry>),
+    Directory {
+        entries: Vec<FileEntry>,
+        sort_column: Option<Vec<Arc<str>>>,
+    },
     File(Text<'static>),
     Empty,
 }
@@ -54,7 +58,7 @@ impl PreviewState {
     /// Sets the selected index, clamped to the length of the current data
     pub(crate) fn set_selected_idx(&mut self, idx: usize) {
         let len = match &self.data {
-            PreviewData::Directory(entries) => entries.len(),
+            PreviewData::Directory { entries, .. } => entries.len(),
             PreviewData::File(_) => 1,
             PreviewData::Empty => 0,
         };
@@ -93,9 +97,17 @@ impl PreviewState {
 
     /// Updates the preview content with new directory entries
     /// Only applies the update if the request ID matches the latest
-    pub(crate) fn update_from_entries(&mut self, entries: Vec<FileEntry>, request_id: u64) {
+    pub(crate) fn update_from_entries(
+        &mut self,
+        entries: Vec<FileEntry>,
+        sort_column: Option<Vec<Arc<str>>>,
+        request_id: u64,
+    ) {
         if request_id == self.request_id {
-            self.data = PreviewData::Directory(entries);
+            self.data = PreviewData::Directory {
+                entries,
+                sort_column,
+            };
             self.selected_idx = 0;
         }
     }
@@ -119,7 +131,7 @@ impl PreviewData {
     #[inline]
     pub(crate) fn is_empty(&self) -> bool {
         match self {
-            PreviewData::Directory(v) => v.is_empty(),
+            PreviewData::Directory { entries, .. } => entries.is_empty(),
             PreviewData::File(text) => text.lines.is_empty(),
             PreviewData::Empty => true,
         }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -590,6 +590,26 @@ impl<'a> AppState<'a> {
         });
     }
 
+    pub(crate) fn request_dir_resort(&mut self, workers: &Workers, focus: Option<OsString>) {
+        self.is_loading = true;
+        let request_id = self.nav.prepare_new_request();
+        let sort_config = self.nav.sort_config();
+        let list_date_format: Arc<str> = Arc::from(self.config.display().list_date_format());
+        let entries = self.nav.entries().to_vec();
+
+        let _ = workers.sort_io_tx().try_send(WorkerTask::ResortDirectory {
+            path: self.nav.current_dir().to_path_buf(),
+            entries,
+            focus,
+            list: self.dir_list_options(),
+            sort_config,
+            list_date_format,
+            always_show: Arc::clone(self.config.general().always_show()),
+            request_id,
+            tab_id: self.tab_id(),
+        });
+    }
+
     fn dir_list_options(&self) -> DirListOptions {
         DirListOptions {
             dirs_first: self.config.general().dirs_first(),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -22,7 +22,7 @@ use crate::app::metadata::MetadataState;
 use crate::app::{Clipboard, NavState, ParentState, PreviewState};
 use crate::config::Config;
 use crate::core::formatter::DirListOptions;
-use crate::core::metadata::{FileMetadataCache, MetadataNeeds};
+use crate::core::metadata::{FileMetadataCache, MetadataNeeds, bump_meta_sort_epoch};
 use crate::core::worker::{WorkerResponse, WorkerTask, Workers};
 use crate::ui::overlays::{OverlayKind, OverlayStack};
 
@@ -390,6 +390,7 @@ impl<'a> AppState<'a> {
 
             WorkerResponse::OperationComplete { need_reload, focus } => {
                 if need_reload {
+                    bump_meta_sort_epoch();
                     self.request_dir_load(workers, focus);
                     self.request_parent_content(workers);
                 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -470,6 +470,7 @@ impl<'a> AppState<'a> {
     pub(crate) fn request_dir_load(&mut self, workers: &Workers, focus: Option<OsString>) {
         self.is_loading = true;
         let request_id = self.nav.prepare_new_request();
+        let sort_config = self.nav.sort_config();
         let _ = workers.nav_io_tx().try_send(WorkerTask::LoadDirectory {
             path: self.nav.current_dir().to_path_buf(),
             focus,
@@ -478,6 +479,7 @@ impl<'a> AppState<'a> {
             show_symlink: self.config.general().show_symlink(),
             show_system: self.config.general().show_system(),
             case_insensitive: self.config.general().case_insensitive(),
+            sort_config,
             always_show: Arc::clone(self.config.general().always_show()),
             request_id,
             tab_id: self.tab_id(),
@@ -489,6 +491,7 @@ impl<'a> AppState<'a> {
         if let Some(entry) = self.nav.selected_entry() {
             let path = self.nav.current_dir().join(entry.name());
             let req_id = self.preview.prepare_new_request(path.clone());
+            let sort_config = self.nav.sort_config();
 
             if entry.is_dir() || entry.is_symlink() {
                 let _ = workers.preview_io_tx().try_send(WorkerTask::LoadDirectory {
@@ -499,6 +502,7 @@ impl<'a> AppState<'a> {
                     show_symlink: self.config.general().show_symlink(),
                     show_system: self.config.general().show_system(),
                     case_insensitive: self.config.general().case_insensitive(),
+                    sort_config,
                     always_show: Arc::clone(self.config.general().always_show()),
                     request_id: req_id,
                     tab_id: self.tab_id(),
@@ -540,6 +544,7 @@ impl<'a> AppState<'a> {
 
         let parent_path_buf = parent_path.to_path_buf();
         let req_id = self.parent.prepare_new_request(&parent_path_buf);
+        let sort_config = self.nav.sort_config();
         let _ = workers.parent_io_tx().try_send(WorkerTask::LoadDirectory {
             path: parent_path_buf,
             focus: None,
@@ -548,6 +553,7 @@ impl<'a> AppState<'a> {
             show_symlink: self.config.general().show_symlink(),
             show_system: self.config.general().show_system(),
             case_insensitive: self.config.general().case_insensitive(),
+            sort_config,
             always_show: Arc::clone(self.config.general().always_show()),
             request_id: req_id,
             tab_id: self.tab_id(),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -592,7 +592,7 @@ impl<'a> AppState<'a> {
 
     pub(crate) fn request_dir_resort(&mut self, workers: &Workers, focus: Option<OsString>) {
         self.is_loading = true;
-        let request_id = self.nav.prepare_new_request();
+        let request_id = self.nav.request_id();
         let sort_config = self.nav.sort_config();
         let list_date_format: Arc<str> = Arc::from(self.config.display().list_date_format());
         let entries = self.nav.entries().to_vec();

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -323,12 +323,14 @@ impl<'a> AppState<'a> {
                 path,
                 entries,
                 focus,
+                sort_column,
                 request_id,
                 tab_id: _tab_id,
             } => {
                 // only update nav if BOTH the ID and path match.
                 if request_id == self.nav.request_id() && path == self.nav.current_dir() {
-                    self.nav.update_from_worker(path, entries, focus);
+                    self.nav
+                        .update_from_worker(path, entries, sort_column, focus);
                     self.is_loading = false;
 
                     self.request_parent_content(workers);
@@ -343,7 +345,8 @@ impl<'a> AppState<'a> {
                     && path.parent() == Some(self.nav.current_dir())
                     && path.file_name() == Some(entry.name())
                 {
-                    self.preview.update_from_entries(entries, request_id);
+                    self.preview
+                        .update_from_entries(entries, sort_column, request_id);
 
                     let sel_path = self.nav.current_dir().join(entry.name());
                     let pos = self.nav.get_position().get(&sel_path).copied().unwrap_or(0);
@@ -368,6 +371,7 @@ impl<'a> AppState<'a> {
                             request_id,
                             &path,
                             sort_config,
+                            sort_column,
                         );
                     }
                 }
@@ -476,6 +480,7 @@ impl<'a> AppState<'a> {
         self.is_loading = true;
         let request_id = self.nav.prepare_new_request();
         let sort_config = self.nav.sort_config();
+        let list_date_format: Arc<str> = Arc::from(self.config.display().list_date_format());
         let _ = workers.nav_io_tx().try_send(WorkerTask::LoadDirectory {
             path: self.nav.current_dir().to_path_buf(),
             focus,
@@ -485,6 +490,7 @@ impl<'a> AppState<'a> {
             show_system: self.config.general().show_system(),
             case_insensitive: self.config.general().case_insensitive(),
             sort_config,
+            list_date_format,
             always_show: Arc::clone(self.config.general().always_show()),
             request_id,
             tab_id: self.tab_id(),
@@ -498,6 +504,7 @@ impl<'a> AppState<'a> {
             let req_id = self.preview.prepare_new_request(path.clone());
             let sort_config = self.nav.sort_config();
 
+            let list_date_format: Arc<str> = Arc::from(self.config.display().list_date_format());
             if entry.is_dir() || entry.is_symlink() {
                 let _ = workers.preview_io_tx().try_send(WorkerTask::LoadDirectory {
                     path,
@@ -508,6 +515,7 @@ impl<'a> AppState<'a> {
                     show_system: self.config.general().show_system(),
                     case_insensitive: self.config.general().case_insensitive(),
                     sort_config,
+                    list_date_format,
                     always_show: Arc::clone(self.config.general().always_show()),
                     request_id: req_id,
                     tab_id: self.tab_id(),
@@ -550,6 +558,7 @@ impl<'a> AppState<'a> {
 
         let parent_path_buf = parent_path.to_path_buf();
         let sort_config = self.nav.sort_config();
+        let list_date_format: Arc<str> = Arc::from(self.config.display().list_date_format());
         let req_id = self
             .parent
             .prepare_new_request(&parent_path_buf, sort_config);
@@ -562,6 +571,7 @@ impl<'a> AppState<'a> {
             show_system: self.config.general().show_system(),
             case_insensitive: self.config.general().case_insensitive(),
             sort_config,
+            list_date_format,
             always_show: Arc::clone(self.config.general().always_show()),
             request_id: req_id,
             tab_id: self.tab_id(),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -21,6 +21,7 @@ use crate::app::keymap::{Action, Keymap, TabAction};
 use crate::app::metadata::MetadataState;
 use crate::app::{Clipboard, NavState, ParentState, PreviewState};
 use crate::config::Config;
+use crate::core::formatter::DirListOptions;
 use crate::core::metadata::{FileMetadataCache, MetadataNeeds};
 use crate::core::worker::{WorkerResponse, WorkerTask, Workers};
 use crate::ui::overlays::{OverlayKind, OverlayStack};
@@ -484,11 +485,7 @@ impl<'a> AppState<'a> {
         let _ = workers.nav_io_tx().try_send(WorkerTask::LoadDirectory {
             path: self.nav.current_dir().to_path_buf(),
             focus,
-            dirs_first: self.config.general().dirs_first(),
-            show_hidden: self.config.general().show_hidden(),
-            show_symlink: self.config.general().show_symlink(),
-            show_system: self.config.general().show_system(),
-            case_insensitive: self.config.general().case_insensitive(),
+            list: self.dir_list_options(),
             sort_config,
             list_date_format,
             always_show: Arc::clone(self.config.general().always_show()),
@@ -509,11 +506,7 @@ impl<'a> AppState<'a> {
                 let _ = workers.preview_io_tx().try_send(WorkerTask::LoadDirectory {
                     path,
                     focus: None,
-                    dirs_first: self.config.general().dirs_first(),
-                    show_hidden: self.config.general().show_hidden(),
-                    show_symlink: self.config.general().show_symlink(),
-                    show_system: self.config.general().show_system(),
-                    case_insensitive: self.config.general().case_insensitive(),
+                    list: self.dir_list_options(),
                     sort_config,
                     list_date_format,
                     always_show: Arc::clone(self.config.general().always_show()),
@@ -565,11 +558,7 @@ impl<'a> AppState<'a> {
         let _ = workers.parent_io_tx().try_send(WorkerTask::LoadDirectory {
             path: parent_path_buf,
             focus: None,
-            dirs_first: self.config.general().dirs_first(),
-            show_hidden: self.config.general().show_hidden(),
-            show_symlink: self.config.general().show_symlink(),
-            show_system: self.config.general().show_system(),
-            case_insensitive: self.config.general().case_insensitive(),
+            list: self.dir_list_options(),
             sort_config,
             list_date_format,
             always_show: Arc::clone(self.config.general().always_show()),
@@ -599,6 +588,16 @@ impl<'a> AppState<'a> {
             cancel: cancel_token,
             tab_id: self.tab_id(),
         });
+    }
+
+    fn dir_list_options(&self) -> DirListOptions {
+        DirListOptions {
+            dirs_first: self.config.general().dirs_first(),
+            show_hidden: self.config.general().show_hidden(),
+            show_symlink: self.config.general().show_symlink(),
+            show_system: self.config.general().show_system(),
+            case_insensitive: self.config.general().case_insensitive(),
+        }
     }
 }
 
@@ -730,6 +729,7 @@ mod tests {
             .to_path_buf();
 
         let prev_request_id = app.parent.request_id();
+        let sort_config = app.nav.sort_config();
 
         let file_entry = FileEntry::new(OsString::from("test_file"), 0, None);
         let dir_entry = FileEntry::new(OsString::from("test_dir"), 1, None);
@@ -739,6 +739,8 @@ mod tests {
             "irrelevant",
             prev_request_id,
             &parent_path,
+            sort_config,
+            None,
         );
 
         app.request_parent_content(&workers);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -361,9 +361,14 @@ impl<'a> AppState<'a> {
                             .file_name()
                             .map(|n| n.to_string_lossy().to_string())
                             .unwrap_or_default();
-
-                        self.parent
-                            .update_from_entries(entries, &current_name, request_id, &path);
+                        let sort_config = self.nav.sort_config();
+                        self.parent.update_from_entries(
+                            entries,
+                            &current_name,
+                            request_id,
+                            &path,
+                            sort_config,
+                        );
                     }
                 }
             }
@@ -538,13 +543,16 @@ impl<'a> AppState<'a> {
             return;
         };
 
-        if self.parent.is_cached(parent_path) {
+        let sort_config = self.nav.sort_config();
+        if self.parent.is_cached(parent_path, sort_config) {
             return;
         }
 
         let parent_path_buf = parent_path.to_path_buf();
-        let req_id = self.parent.prepare_new_request(&parent_path_buf);
         let sort_config = self.nav.sort_config();
+        let req_id = self
+            .parent
+            .prepare_new_request(&parent_path_buf, sort_config);
         let _ = workers.parent_io_tx().try_send(WorkerTask::LoadDirectory {
             path: parent_path_buf,
             focus: None,

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -36,6 +36,11 @@ pub(crate) struct Display {
     scroll_padding: usize,
     toggle_marker_jump: bool,
     instant_preview: bool,
+    #[serde(
+        default = "Display::default_list_date_format",
+        deserialize_with = "deserialize_list_date_format"
+    )]
+    list_date_format: String,
     preview_options: PreviewOptions,
     layout: LayoutConfig,
     info: ShowInfoOptions,
@@ -93,6 +98,15 @@ impl Display {
         self.layout.preview_ratio()
     }
 
+    fn default_list_date_format() -> String {
+        "%b %e %H:%M".to_string()
+    }
+
+    #[inline]
+    pub(crate) fn list_date_format(&self) -> &str {
+        &self.list_date_format
+    }
+
     /// Get padding string based on entry_padding
     pub(crate) fn padding_str(&self) -> &'static str {
         // ASCII whitespaces
@@ -125,6 +139,7 @@ impl Default for Display {
             scroll_padding: 5,
             toggle_marker_jump: false,
             instant_preview: true,
+            list_date_format: Display::default_list_date_format(),
             layout: LayoutConfig::default(),
             preview_options: PreviewOptions::default(),
             info: ShowInfoOptions::default(),
@@ -216,31 +231,7 @@ impl ShowInfoOptions {
     }
 
     fn validate_date_format(fmt: Option<String>) -> String {
-        let default_fmt = "%Y-%m-%d %H:%M".to_string();
-
-        let Some(user_str) = fmt else {
-            return default_fmt;
-        };
-
-        if user_str.is_empty() || user_str.len() > 64 {
-            return default_fmt;
-        }
-
-        let mut has_date_specifier = false;
-
-        for item in StrftimeItems::new(&user_str) {
-            match item {
-                Item::Error => return default_fmt,
-                Item::Space(_) | Item::Literal(_) => continue,
-                _ => has_date_specifier = true,
-            }
-        }
-
-        if has_date_specifier {
-            user_str
-        } else {
-            default_fmt
-        }
+        validate_strftime_format(fmt, "%Y-%m-%d %H:%M", 64)
     }
 }
 
@@ -594,4 +585,38 @@ fn parse_status_format(fmt: &str) -> Vec<StatusSegment> {
         segments.push(StatusSegment::Literal(fmt[cursor..].to_string()));
     }
     segments
+}
+
+fn validate_strftime_format(fmt: Option<String>, default_fmt: &str, max_len: usize) -> String {
+    let Some(user_str) = fmt else {
+        return default_fmt.to_string();
+    };
+
+    if user_str.is_empty() || user_str.len() > max_len {
+        return default_fmt.to_string();
+    }
+
+    let mut has_date_specifier = false;
+
+    for item in StrftimeItems::new(&user_str) {
+        match item {
+            Item::Error => return default_fmt.to_string(),
+            Item::Space(_) | Item::Literal(_) => continue,
+            _ => has_date_specifier = true,
+        }
+    }
+
+    if has_date_specifier {
+        user_str
+    } else {
+        default_fmt.to_string()
+    }
+}
+
+fn deserialize_list_date_format<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: Option<String> = Option::<String>::deserialize(deserializer)?;
+    Ok(validate_strftime_format(raw, "%b %e %H:%M", 32))
 }

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -34,6 +34,7 @@ pub(crate) struct Keys {
     clear_all: Vec<String>,
     alternate_delete: Vec<String>,
     select_all: Vec<String>,
+    prefix_go_to: Vec<String>,
     go_to_top: Vec<String>,
     go_to_home: Vec<String>,
     go_to_path: Vec<String>,
@@ -45,6 +46,7 @@ pub(crate) struct Keys {
     keybind_help: Vec<String>,
     scroll_up: Vec<String>,
     scroll_down: Vec<String>,
+    sort: Vec<String>,
 }
 
 crate::key_accessor!(
@@ -71,6 +73,7 @@ crate::key_accessor!(
     clear_all,
     alternate_delete,
     select_all,
+    prefix_go_to,
     go_to_top,
     go_to_home,
     go_to_path,
@@ -82,6 +85,7 @@ crate::key_accessor!(
     keybind_help,
     scroll_up,
     scroll_down,
+    sort,
 );
 
 /// Default input configuration options
@@ -116,6 +120,8 @@ impl Default for Keys {
 
             alternate_delete: vec!["<m-d>".into()],
 
+            prefix_go_to: vec!["g".into()],
+
             go_to_top: vec!["g".into()],
             go_to_home: vec!["h".into()],
             go_to_path: vec!["p".into()],
@@ -130,6 +136,8 @@ impl Default for Keys {
 
             scroll_up: vec!["<c-d>".into()],
             scroll_down: vec!["<c-u>".into()],
+
+            sort: vec!["o".into()],
         }
     }
 }

--- a/src/core/formatter.rs
+++ b/src/core/formatter.rs
@@ -33,14 +33,27 @@ const HEADER_PEEK_BYTES: usize = 8;
 // Bytes to peek for null bytes in binary detections
 const BINARY_PEEK_BYTES: usize = 1024;
 
+#[derive(Clone)]
+pub(crate) struct DirListOptions {
+    pub(crate) dirs_first: bool,
+    pub(crate) show_hidden: bool,
+    pub(crate) show_symlink: bool,
+    pub(crate) show_system: bool,
+    pub(crate) case_insensitive: bool,
+}
+
+#[derive(Clone, Copy)]
+enum MetadataSortField {
+    Size,
+    Modified,
+    Created,
+    Accessed,
+}
+
 /// Formatter struct to handle sorting, filtering, and formatting of file entries
 /// based on user preferences.
 pub(crate) struct Formatter {
-    dirs_first: bool,
-    show_hidden: bool,
-    show_symlink: bool,
-    show_system: bool,
-    case_insensitive: bool,
+    list: DirListOptions,
     sort_config: SortConfig,
     always_show: Option<Arc<HashSet<OsString>>>,
     always_show_lowercase: Option<Arc<HashSet<String>>>,
@@ -51,17 +64,13 @@ impl Formatter {
     const PRIO_FILE: u8 = 1;
 
     pub(crate) fn new(
-        dirs_first: bool,
-        show_hidden: bool,
-        show_symlink: bool,
-        show_system: bool,
-        case_insensitive: bool,
+        list: DirListOptions,
         sort_config: SortConfig,
         always_show: Arc<HashSet<OsString>>,
     ) -> Self {
         let (always_show, always_show_lowercase) = if always_show.is_empty() {
             (None, None)
-        } else if case_insensitive {
+        } else if list.case_insensitive {
             let lower = Arc::new(
                 always_show
                     .iter()
@@ -74,11 +83,7 @@ impl Formatter {
         };
 
         Self {
-            dirs_first,
-            show_hidden,
-            show_symlink,
-            show_system,
-            case_insensitive,
+            list,
             sort_config,
             always_show,
             always_show_lowercase,
@@ -87,7 +92,7 @@ impl Formatter {
 
     #[inline]
     fn prio_for_entry(&self, entry: &FileEntry) -> u8 {
-        if self.dirs_first && (entry.flags() & FileEntry::IS_DIR) != 0 {
+        if self.list.dirs_first && (entry.flags() & FileEntry::IS_DIR) != 0 {
             Self::PRIO_DIR
         } else {
             Self::PRIO_FILE
@@ -137,10 +142,10 @@ impl Formatter {
         }
     }
 
-    fn sort_by_name(&self, entries: &mut Vec<FileEntry>) {
+    fn sort_by_name(&self, entries: &mut [FileEntry]) {
         let sort_order = self.sort_config.order;
 
-        if !self.case_insensitive {
+        if !self.list.case_insensitive {
             entries.sort_by(|left_entry, right_entry| {
                 let left_priority = self.prio_for_entry(left_entry);
                 let right_priority = self.prio_for_entry(right_entry);
@@ -180,7 +185,7 @@ impl Formatter {
     fn sort_by_extension(&self, entries: &mut Vec<FileEntry>) {
         let sort_order = self.sort_config.order;
 
-        if !self.case_insensitive {
+        if !self.list.case_insensitive {
             let mut sort_keys: Vec<(u8, Option<&OsStr>, &OsStr, usize)> =
                 Vec::with_capacity(entries.len());
 
@@ -196,8 +201,8 @@ impl Formatter {
                 }
 
                 match sort_order {
-                    SortOrder::Ascending => left.1.cmp(&right.1).then(left.2.cmp(&right.2)),
-                    SortOrder::Descending => right.1.cmp(&left.1).then(right.2.cmp(&left.2)),
+                    SortOrder::Ascending => left.1.cmp(&right.1).then(left.2.cmp(right.2)),
+                    SortOrder::Descending => right.1.cmp(&left.1).then(right.2.cmp(left.2)),
                 }
             });
 
@@ -334,7 +339,7 @@ impl Formatter {
                 return primary;
             }
 
-            if !self.case_insensitive {
+            if !self.list.case_insensitive {
                 return entries[left.2].name().cmp(entries[right.2].name());
             }
 
@@ -365,20 +370,20 @@ impl Formatter {
 
     pub(crate) fn filter_entries(&self, entries: &mut Vec<FileEntry>) {
         let mut hide = 0u8;
-        if !self.show_hidden {
+        if !self.list.show_hidden {
             hide |= FileEntry::IS_HIDDEN;
         }
-        if !self.show_system {
+        if !self.list.show_system {
             hide |= FileEntry::IS_SYSTEM;
         }
-        if !self.show_symlink {
+        if !self.list.show_symlink {
             hide |= FileEntry::IS_SYMLINK;
         }
         entries.retain(|e| {
             let flags = e.flags();
 
             if (flags & hide) != 0 {
-                if self.case_insensitive {
+                if self.list.case_insensitive {
                     if let Some(set) = &self.always_show_lowercase {
                         return with_lowered_stack(e.name_str().as_ref(), |lowered| {
                             set.contains(lowered)
@@ -646,14 +651,6 @@ pub(crate) fn safe_read_preview(path: &Path, max_lines: usize, pane_width: usize
     }
 }
 
-#[derive(Clone, Copy)]
-enum MetadataSortField {
-    Size,
-    Modified,
-    Created,
-    Accessed,
-}
-
 #[inline]
 fn system_time_to_key(system_time: Option<SystemTime>) -> u128 {
     system_time
@@ -700,46 +697,55 @@ mod tests {
         }
     }
 
-    // #[test]
-    // fn formatter_filters_entries_by_flags() {
-    //     let normal = FileEntry::new(OsString::from("normal.txt"), 0, None);
-    //     let hidden = FileEntry::new(OsString::from(".hidden"), FileEntry::IS_HIDDEN, None);
-    //     let system = FileEntry::new(OsString::from("system.sys"), FileEntry::IS_SYSTEM, None);
-    //     let symlink = FileEntry::new(
-    //         OsString::from("symlink"),
-    //         FileEntry::IS_SYMLINK,
-    //         Some(Path::new("target").to_path_buf()),
-    //     );
-    //
-    //     let mut entries = vec![
-    //         normal.clone(),
-    //         hidden.clone(),
-    //         system.clone(),
-    //         symlink.clone(),
-    //     ];
-    //
-    //     let fmt = Formatter::new(true, false, false, false, false, Arc::new(HashSet::new()));
-    //     fmt.filter_entries(&mut entries);
-    //
-    //     assert_eq!(entries.len(), 1);
-    //     assert_eq!(entries[0].name_str(), "normal.txt");
-    //
-    //     let mut entries = vec![
-    //         normal.clone(),
-    //         hidden.clone(),
-    //         system.clone(),
-    //         symlink.clone(),
-    //     ];
-    //
-    //     let fmt = Formatter::new(true, true, true, true, false, Arc::new(HashSet::new()));
-    //     fmt.filter_entries(&mut entries);
-    //     assert_eq!(entries.len(), 4);
-    //     assert!(entries.iter().any(|e| e.name_str() == ".hidden"));
-    //     assert!(entries.iter().any(|e| e.name_str() == "system.sys"));
-    //     assert!(entries.iter().any(|e| e.name_str() == "symlink"));
-    //     assert!(entries.iter().any(|e| e.name_str() == "normal.txt"));
-    // }
-    //
+    #[test]
+    fn formatter_filters_entries_by_flags() {
+        let normal = FileEntry::new(OsString::from("normal.txt"), 0, None);
+        let hidden = FileEntry::new(OsString::from(".hidden"), FileEntry::IS_HIDDEN, None);
+        let system = FileEntry::new(OsString::from("system.sys"), FileEntry::IS_SYSTEM, None);
+        let symlink = FileEntry::new(
+            OsString::from("symlink"),
+            FileEntry::IS_SYMLINK,
+            Some(Path::new("target").to_path_buf()),
+        );
+
+        let mut entries = vec![
+            normal.clone(),
+            hidden.clone(),
+            system.clone(),
+            symlink.clone(),
+        ];
+
+        let list = DirListOptions {
+            dirs_first: true,
+            show_hidden: false,
+            show_system: false,
+            show_symlink: false,
+            case_insensitive: true,
+        };
+        let short_config = SortConfig::default();
+
+        let fmt = Formatter::new(list.to_owned(), short_config, Arc::new(HashSet::new()));
+        fmt.filter_entries(&mut entries);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name_str(), "normal.txt");
+
+        let mut entries = vec![
+            normal.clone(),
+            hidden.clone(),
+            system.clone(),
+            symlink.clone(),
+        ];
+
+        let fmt = Formatter::new(list, short_config, Arc::new(HashSet::new()));
+        fmt.filter_entries(&mut entries);
+        assert_eq!(entries.len(), 4);
+        assert!(entries.iter().any(|e| e.name_str() == ".hidden"));
+        assert!(entries.iter().any(|e| e.name_str() == "system.sys"));
+        assert!(entries.iter().any(|e| e.name_str() == "symlink"));
+        assert!(entries.iter().any(|e| e.name_str() == "normal.txt"));
+    }
+
     #[test]
     fn core_empty_dir() -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempdir()?;

--- a/src/core/formatter.rs
+++ b/src/core/formatter.rs
@@ -8,7 +8,7 @@
 
 use crate::app::nav::{SortConfig, SortMode, SortOrder};
 use crate::core::FileEntry;
-use crate::core::metadata::FileType;
+use crate::core::metadata::{FileType, get_or_update_cached_meta};
 use crate::utils::{clean_display_path, is_regular_file, shorten_home_path, with_lowered_stack};
 
 use chrono::{DateTime, Local};
@@ -316,43 +316,36 @@ impl Formatter {
 
         for (index, file_entry) in entries.iter().enumerate() {
             let priority = self.prio_for_entry(file_entry);
-
             let full_path = directory_path.join(file_entry.name());
-            let metadata = std::fs::symlink_metadata(&full_path).ok();
 
-            let (metadata_key_value, display): (u128, Arc<str>) = match metadata_sort_field {
-                MetadataSortField::Size => {
-                    let size = metadata.as_ref().filter(|m| m.is_file()).map(|m| m.len());
-                    let key = size.unwrap_or(0) as u128;
-                    let s = format_file_size(size, file_entry.is_dir());
-                    (key, Arc::from(s))
-                }
+            if let Some(cached) = get_or_update_cached_meta(&full_path) {
+                let (metadata_key_value, display): (u128, Arc<str>) = match metadata_sort_field {
+                    MetadataSortField::Size => {
+                        let key = cached.size.unwrap_or(0) as u128;
+                        let s = format_file_size(cached.size, file_entry.is_dir());
+                        (key, Arc::from(s))
+                    }
+                    MetadataSortField::Modified => (
+                        system_time_to_key(cached.modified),
+                        Arc::from(format_file_time(cached.modified, list_date_format)),
+                    ),
+                    MetadataSortField::Created => (
+                        system_time_to_key(cached.created),
+                        Arc::from(format_file_time(cached.created, list_date_format)),
+                    ),
+                    MetadataSortField::Accessed => (
+                        system_time_to_key(cached.accessed),
+                        Arc::from(format_file_time(cached.accessed, list_date_format)),
+                    ),
+                };
 
-                MetadataSortField::Modified => {
-                    let t = metadata.as_ref().and_then(|m| m.modified().ok());
-                    (
-                        system_time_to_key(t),
-                        Arc::from(format_file_time(t, list_date_format)),
-                    )
-                }
-                MetadataSortField::Created => {
-                    let t = metadata.as_ref().and_then(|m| m.created().ok());
-                    (
-                        system_time_to_key(t),
-                        Arc::from(format_file_time(t, list_date_format)),
-                    )
-                }
-                MetadataSortField::Accessed => {
-                    let t = metadata.as_ref().and_then(|m| m.accessed().ok());
-                    (
-                        system_time_to_key(t),
-                        Arc::from(format_file_time(t, list_date_format)),
-                    )
-                }
-            };
-
-            keys.push((priority, metadata_key_value, index));
-            column.push(display);
+                keys.push((priority, metadata_key_value, index));
+                column.push(display);
+            } else {
+                let display = Arc::from("-");
+                keys.push((priority, 0, index));
+                column.push(display);
+            }
         }
 
         let sort_order = self.sort_config.order;
@@ -704,62 +697,62 @@ fn natural_cmp_bytes(a: &[u8], b: &[u8], fold_case: bool) -> Ordering {
     let mut j = 0usize;
 
     while i < a.len() && j < b.len() {
-        let ad = a[i].is_ascii_digit();
-        let bd = b[j].is_ascii_digit();
+        let a_is_digit = a[i].is_ascii_digit();
+        let b_is_digit = b[j].is_ascii_digit();
 
-        if ad && bd {
-            let ia0 = i;
+        if a_is_digit && b_is_digit {
+            let start_i = i;
             while i < a.len() && a[i].is_ascii_digit() {
                 i += 1;
             }
-            let jb0 = j;
+            let start_j = j;
             while j < b.len() && b[j].is_ascii_digit() {
                 j += 1;
             }
 
-            let mut ia = ia0;
-            while ia < i && a[ia] == b'0' {
-                ia += 1;
+            let mut nonzero_i = start_i;
+            while nonzero_i < i && a[nonzero_i] == b'0' {
+                nonzero_i += 1;
             }
-            let mut jb = jb0;
-            while jb < j && b[jb] == b'0' {
-                jb += 1;
-            }
-
-            let lena = i - ia;
-            let lenb = j - jb;
-
-            if lena != lenb {
-                return lena.cmp(&lenb);
+            let mut nonzero_j = start_j;
+            while nonzero_j < j && b[nonzero_j] == b'0' {
+                nonzero_j += 1;
             }
 
-            for k in 0..lena {
-                let ca = a[ia + k];
-                let cb = b[jb + k];
-                if ca != cb {
-                    return ca.cmp(&cb);
+            let len_i = i - nonzero_i;
+            let len_j = j - nonzero_j;
+
+            if len_i != len_j {
+                return len_i.cmp(&len_j);
+            }
+
+            for digit_offset in 0..len_i {
+                let digit_i = a[nonzero_i + digit_offset];
+                let digit_j = b[nonzero_j + digit_offset];
+                if digit_i != digit_j {
+                    return digit_i.cmp(&digit_j);
                 }
             }
 
-            let za = ia - ia0;
-            let zb = jb - jb0;
-            if za != zb {
-                return za.cmp(&zb);
+            let leading_zeros_i = nonzero_i - start_i;
+            let leading_zeros_j = nonzero_j - start_j;
+            if leading_zeros_i != leading_zeros_j {
+                return leading_zeros_i.cmp(&leading_zeros_j);
             }
 
             continue;
         }
 
-        let mut ca = a[i];
-        let mut cb = b[j];
+        let mut byte_i = a[i];
+        let mut byte_j = b[j];
 
-        if fold_case && (ca.is_ascii_uppercase() || cb.is_ascii_uppercase()) {
-            ca = ca.to_ascii_lowercase();
-            cb = cb.to_ascii_lowercase();
+        if fold_case && (byte_i.is_ascii_uppercase() || byte_j.is_ascii_uppercase()) {
+            byte_i = byte_i.to_ascii_lowercase();
+            byte_j = byte_j.to_ascii_lowercase();
         }
 
-        if ca != cb {
-            return ca.cmp(&cb);
+        if byte_i != byte_j {
+            return byte_i.cmp(&byte_j);
         }
 
         i += 1;

--- a/src/core/formatter.rs
+++ b/src/core/formatter.rs
@@ -107,8 +107,12 @@ impl Formatter {
         list_date_format: &str,
     ) -> Option<Vec<Arc<str>>> {
         match self.sort_config.mode {
-            SortMode::Natural | SortMode::Name => {
+            SortMode::Name => {
                 self.sort_by_name(entries);
+                None
+            }
+            SortMode::Natural => {
+                self.sort_by_natural(entries);
                 None
             }
             SortMode::Extension => {
@@ -179,6 +183,34 @@ impl Formatter {
                     SortOrder::Descending => right_lower.cmp(left_lower),
                 })
             })
+        });
+    }
+
+    fn sort_by_natural(&self, entries: &mut [FileEntry]) {
+        let sort_order = self.sort_config.order;
+        let case_insensitive = self.list.case_insensitive;
+
+        entries.sort_by(|left_entry, right_entry| {
+            let left_priority = self.prio_for_entry(left_entry);
+            let right_priority = self.prio_for_entry(right_entry);
+
+            if left_priority != right_priority {
+                return left_priority.cmp(&right_priority);
+            }
+
+            let left = left_entry.name_str();
+            let right = right_entry.name_str();
+
+            let ord = if case_insensitive {
+                natural_cmp_ascii_ci(left.as_ref(), right.as_ref())
+            } else {
+                natural_cmp_ascii(left.as_ref(), right.as_ref())
+            };
+
+            match sort_order {
+                SortOrder::Ascending => ord,
+                SortOrder::Descending => ord.reverse(),
+            }
         });
     }
 
@@ -657,6 +689,84 @@ fn system_time_to_key(system_time: Option<SystemTime>) -> u128 {
         .and_then(|st| st.duration_since(UNIX_EPOCH).ok())
         .map(|duration| duration.as_nanos())
         .unwrap_or(0)
+}
+
+fn natural_cmp_ascii(a: &str, b: &str) -> Ordering {
+    natural_cmp_bytes(a.as_bytes(), b.as_bytes(), false)
+}
+
+fn natural_cmp_ascii_ci(a: &str, b: &str) -> Ordering {
+    natural_cmp_bytes(a.as_bytes(), b.as_bytes(), true)
+}
+
+fn natural_cmp_bytes(a: &[u8], b: &[u8], fold_case: bool) -> Ordering {
+    let mut i = 0usize;
+    let mut j = 0usize;
+
+    while i < a.len() && j < b.len() {
+        let ad = a[i].is_ascii_digit();
+        let bd = b[j].is_ascii_digit();
+
+        if ad && bd {
+            let ia0 = i;
+            while i < a.len() && a[i].is_ascii_digit() {
+                i += 1;
+            }
+            let jb0 = j;
+            while j < b.len() && b[j].is_ascii_digit() {
+                j += 1;
+            }
+
+            let mut ia = ia0;
+            while ia < i && a[ia] == b'0' {
+                ia += 1;
+            }
+            let mut jb = jb0;
+            while jb < j && b[jb] == b'0' {
+                jb += 1;
+            }
+
+            let lena = i - ia;
+            let lenb = j - jb;
+
+            if lena != lenb {
+                return lena.cmp(&lenb);
+            }
+
+            for k in 0..lena {
+                let ca = a[ia + k];
+                let cb = b[jb + k];
+                if ca != cb {
+                    return ca.cmp(&cb);
+                }
+            }
+
+            let za = ia - ia0;
+            let zb = jb - jb0;
+            if za != zb {
+                return za.cmp(&zb);
+            }
+
+            continue;
+        }
+
+        let mut ca = a[i];
+        let mut cb = b[j];
+
+        if fold_case && (ca.is_ascii_uppercase() || cb.is_ascii_uppercase()) {
+            ca = ca.to_ascii_lowercase();
+            cb = cb.to_ascii_lowercase();
+        }
+
+        if ca != cb {
+            return ca.cmp(&cb);
+        }
+
+        i += 1;
+        j += 1;
+    }
+
+    a.len().cmp(&b.len())
 }
 
 /// Formatter integration tests

--- a/src/core/formatter.rs
+++ b/src/core/formatter.rs
@@ -6,6 +6,7 @@
 //!
 //! Also formatts FileTypes to be used by FileMetadata and ShowInfo overlay widget.
 
+use crate::app::nav::{SortConfig, SortMode, SortOrder};
 use crate::core::FileEntry;
 use crate::core::metadata::FileType;
 use crate::utils::{clean_display_path, is_regular_file, shorten_home_path, with_lowered_stack};
@@ -14,13 +15,14 @@ use chrono::{DateTime, Local};
 use humansize::{DECIMAL, format_size};
 use unicode_width::UnicodeWidthChar;
 
+use std::cmp::Ordering;
 use std::collections::HashSet;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs::{File, Metadata};
 use std::io::{BufRead, BufReader, ErrorKind, Read, Seek};
 use std::path::Path;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // Minimum number of lines shown in any preview
 const MIN_PREVIEW_LINES: usize = 3;
@@ -39,6 +41,7 @@ pub(crate) struct Formatter {
     show_symlink: bool,
     show_system: bool,
     case_insensitive: bool,
+    sort_config: SortConfig,
     always_show: Option<Arc<HashSet<OsString>>>,
     always_show_lowercase: Option<Arc<HashSet<String>>>,
 }
@@ -53,6 +56,7 @@ impl Formatter {
         show_symlink: bool,
         show_system: bool,
         case_insensitive: bool,
+        sort_config: SortConfig,
         always_show: Arc<HashSet<OsString>>,
     ) -> Self {
         let (always_show, always_show_lowercase) = if always_show.is_empty() {
@@ -75,13 +79,14 @@ impl Formatter {
             show_symlink,
             show_system,
             case_insensitive,
+            sort_config,
             always_show,
             always_show_lowercase,
         }
     }
 
     #[inline]
-    fn get_prio(&self, entry: &FileEntry) -> u8 {
+    fn prio_for_entry(&self, entry: &FileEntry) -> u8 {
         if self.dirs_first && (entry.flags() & FileEntry::IS_DIR) != 0 {
             Self::PRIO_DIR
         } else {
@@ -90,21 +95,239 @@ impl Formatter {
     }
 
     /// Sorts the given file entries in place according to the formatter's settings.
-    pub(crate) fn sort_entries(&self, entries: &mut [FileEntry]) {
-        if self.case_insensitive {
-            entries.sort_by_cached_key(|e| (self.get_prio(e), e.name_str().to_lowercase()));
-        } else {
-            entries.sort_by(|a, b| {
-                if self.dirs_first {
-                    let prio_a = self.get_prio(a);
-                    let prio_b = self.get_prio(b);
-                    if prio_a != prio_b {
-                        return prio_a.cmp(&prio_b);
-                    }
-                }
-                a.name().cmp(b.name())
-            });
+    pub(crate) fn sort_entries(&self, directory_path: &Path, entries: &mut Vec<FileEntry>) {
+        match self.sort_config.mode {
+            SortMode::Natural | SortMode::Name => {
+                self.sort_by_name(entries);
+            }
+            SortMode::Extension => {
+                self.sort_by_extension(entries);
+            }
+            SortMode::Size => {
+                self.sort_by_filesystem_metadata(directory_path, entries, MetadataSortField::Size);
+            }
+            SortMode::Modified => {
+                self.sort_by_filesystem_metadata(
+                    directory_path,
+                    entries,
+                    MetadataSortField::Modified,
+                );
+            }
+            SortMode::Created => {
+                self.sort_by_filesystem_metadata(
+                    directory_path,
+                    entries,
+                    MetadataSortField::Created,
+                );
+            }
+            SortMode::Accessed => {
+                self.sort_by_filesystem_metadata(
+                    directory_path,
+                    entries,
+                    MetadataSortField::Accessed,
+                );
+            }
         }
+    }
+
+    fn sort_by_name(&self, entries: &mut Vec<FileEntry>) {
+        let sort_order = self.sort_config.order;
+
+        if !self.case_insensitive {
+            entries.sort_by(|left_entry, right_entry| {
+                let left_priority = self.prio_for_entry(left_entry);
+                let right_priority = self.prio_for_entry(right_entry);
+
+                if left_priority != right_priority {
+                    return left_priority.cmp(&right_priority);
+                }
+
+                match sort_order {
+                    SortOrder::Ascending => left_entry.name().cmp(right_entry.name()),
+                    SortOrder::Descending => right_entry.name().cmp(left_entry.name()),
+                }
+            });
+            return;
+        }
+
+        entries.sort_by(|left_entry, right_entry| {
+            let left_priority = self.prio_for_entry(left_entry);
+            let right_priority = self.prio_for_entry(right_entry);
+
+            if left_priority != right_priority {
+                return left_priority.cmp(&right_priority);
+            }
+
+            let left_name = left_entry.name_str();
+            let right_name = right_entry.name_str();
+
+            with_lowered_stack(left_name.as_ref(), |left_lower| {
+                with_lowered_stack(right_name.as_ref(), |right_lower| match sort_order {
+                    SortOrder::Ascending => left_lower.cmp(right_lower),
+                    SortOrder::Descending => right_lower.cmp(left_lower),
+                })
+            })
+        });
+    }
+
+    fn sort_by_extension(&self, entries: &mut Vec<FileEntry>) {
+        let sort_order = self.sort_config.order;
+
+        if !self.case_insensitive {
+            let mut sort_keys: Vec<(u8, Option<&OsStr>, &OsStr, usize)> =
+                Vec::with_capacity(entries.len());
+
+            for (original_index, file_entry) in entries.iter().enumerate() {
+                let priority = self.prio_for_entry(file_entry);
+                let extension = Path::new(file_entry.name()).extension();
+                sort_keys.push((priority, extension, file_entry.name(), original_index));
+            }
+
+            sort_keys.sort_by(|left, right| {
+                if left.0 != right.0 {
+                    return left.0.cmp(&right.0);
+                }
+
+                match sort_order {
+                    SortOrder::Ascending => left.1.cmp(&right.1).then(left.2.cmp(&right.2)),
+                    SortOrder::Descending => right.1.cmp(&left.1).then(right.2.cmp(&left.2)),
+                }
+            });
+
+            let mut reordered_entries: Vec<FileEntry> = Vec::with_capacity(entries.len());
+            for (_, _, _, original_index) in sort_keys {
+                reordered_entries.push(entries[original_index].clone());
+            }
+
+            *entries = reordered_entries;
+            return;
+        }
+
+        // Case-insensitive: cache lowered extension + lowered name (no closure borrow of `entries`)
+        let mut sort_keys: Vec<(u8, String, String, usize)> = Vec::with_capacity(entries.len());
+
+        for (original_index, file_entry) in entries.iter().enumerate() {
+            let priority = self.prio_for_entry(file_entry);
+
+            let extension_lossy = Path::new(file_entry.name())
+                .extension()
+                .map(|extension| extension.to_string_lossy())
+                .unwrap_or_default();
+
+            let lowered_extension = if extension_lossy.len() <= 64 {
+                with_lowered_stack(extension_lossy.as_ref(), |lowered| lowered.to_string())
+            } else {
+                extension_lossy.to_lowercase()
+            };
+
+            let name_lossy = file_entry.name_str();
+            let lowered_name = if name_lossy.len() <= 64 {
+                with_lowered_stack(name_lossy.as_ref(), |lowered| lowered.to_string())
+            } else {
+                name_lossy.to_lowercase()
+            };
+
+            sort_keys.push((priority, lowered_extension, lowered_name, original_index));
+        }
+
+        sort_keys.sort_by(|left, right| {
+            if left.0 != right.0 {
+                return left.0.cmp(&right.0);
+            }
+
+            let extension_ordering = match sort_order {
+                SortOrder::Ascending => left.1.cmp(&right.1),
+                SortOrder::Descending => right.1.cmp(&left.1),
+            };
+
+            if extension_ordering != Ordering::Equal {
+                return extension_ordering;
+            }
+
+            match sort_order {
+                SortOrder::Ascending => left.2.cmp(&right.2),
+                SortOrder::Descending => right.2.cmp(&left.2),
+            }
+        });
+
+        let mut reordered_entries: Vec<FileEntry> = Vec::with_capacity(entries.len());
+        for (_, _, _, original_index) in sort_keys {
+            reordered_entries.push(entries[original_index].clone());
+        }
+
+        *entries = reordered_entries;
+    }
+
+    fn sort_by_filesystem_metadata(
+        &self,
+        directory_path: &Path,
+        entries: &mut Vec<FileEntry>,
+        metadata_sort_field: MetadataSortField,
+    ) {
+        let mut keys: Vec<(u8, u128, usize)> = Vec::with_capacity(entries.len());
+
+        for (index, file_entry) in entries.iter().enumerate() {
+            let priority = self.prio_for_entry(file_entry);
+
+            let full_path = directory_path.join(file_entry.name());
+            let metadata = std::fs::symlink_metadata(&full_path).ok();
+
+            let metadata_key_value: u128 = match metadata_sort_field {
+                MetadataSortField::Size => metadata
+                    .as_ref()
+                    .map(|m| if m.is_file() { m.len() as u128 } else { 0 })
+                    .unwrap_or(0),
+
+                MetadataSortField::Modified => {
+                    system_time_to_key(metadata.as_ref().and_then(|m| m.modified().ok()))
+                }
+                MetadataSortField::Created => {
+                    system_time_to_key(metadata.as_ref().and_then(|m| m.created().ok()))
+                }
+                MetadataSortField::Accessed => {
+                    system_time_to_key(metadata.as_ref().and_then(|m| m.accessed().ok()))
+                }
+            };
+
+            keys.push((priority, metadata_key_value, index));
+        }
+
+        let sort_order = self.sort_config.order;
+
+        keys.sort_by(|left, right| {
+            if left.0 != right.0 {
+                return left.0.cmp(&right.0);
+            }
+
+            let primary = match sort_order {
+                SortOrder::Ascending => left.1.cmp(&right.1),
+                SortOrder::Descending => right.1.cmp(&left.1),
+            };
+
+            if primary != Ordering::Equal {
+                return primary;
+            }
+
+            if !self.case_insensitive {
+                return entries[left.2].name().cmp(entries[right.2].name());
+            }
+
+            let left_name = entries[left.2].name_str();
+            let right_name = entries[right.2].name_str();
+
+            with_lowered_stack(left_name.as_ref(), |left_lower| {
+                with_lowered_stack(right_name.as_ref(), |right_lower| match sort_order {
+                    SortOrder::Ascending => left_lower.cmp(right_lower),
+                    SortOrder::Descending => right_lower.cmp(left_lower),
+                })
+            })
+        });
+
+        let old_entries = std::mem::take(entries);
+        *entries = keys
+            .into_iter()
+            .map(|(_, _, index)| old_entries[index].clone())
+            .collect();
     }
 
     pub(crate) fn filter_entries(&self, entries: &mut Vec<FileEntry>) {
@@ -390,6 +613,22 @@ pub(crate) fn safe_read_preview(path: &Path, max_lines: usize, pane_width: usize
     }
 }
 
+#[derive(Clone, Copy)]
+enum MetadataSortField {
+    Size,
+    Modified,
+    Created,
+    Accessed,
+}
+
+#[inline]
+fn system_time_to_key(system_time: Option<SystemTime>) -> u128 {
+    system_time
+        .and_then(|st| st.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
 /// Formatter integration tests
 #[cfg(test)]
 mod tests {
@@ -428,46 +667,46 @@ mod tests {
         }
     }
 
-    #[test]
-    fn formatter_filters_entries_by_flags() {
-        let normal = FileEntry::new(OsString::from("normal.txt"), 0, None);
-        let hidden = FileEntry::new(OsString::from(".hidden"), FileEntry::IS_HIDDEN, None);
-        let system = FileEntry::new(OsString::from("system.sys"), FileEntry::IS_SYSTEM, None);
-        let symlink = FileEntry::new(
-            OsString::from("symlink"),
-            FileEntry::IS_SYMLINK,
-            Some(Path::new("target").to_path_buf()),
-        );
-
-        let mut entries = vec![
-            normal.clone(),
-            hidden.clone(),
-            system.clone(),
-            symlink.clone(),
-        ];
-
-        let fmt = Formatter::new(true, false, false, false, false, Arc::new(HashSet::new()));
-        fmt.filter_entries(&mut entries);
-
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].name_str(), "normal.txt");
-
-        let mut entries = vec![
-            normal.clone(),
-            hidden.clone(),
-            system.clone(),
-            symlink.clone(),
-        ];
-
-        let fmt = Formatter::new(true, true, true, true, false, Arc::new(HashSet::new()));
-        fmt.filter_entries(&mut entries);
-        assert_eq!(entries.len(), 4);
-        assert!(entries.iter().any(|e| e.name_str() == ".hidden"));
-        assert!(entries.iter().any(|e| e.name_str() == "system.sys"));
-        assert!(entries.iter().any(|e| e.name_str() == "symlink"));
-        assert!(entries.iter().any(|e| e.name_str() == "normal.txt"));
-    }
-
+    // #[test]
+    // fn formatter_filters_entries_by_flags() {
+    //     let normal = FileEntry::new(OsString::from("normal.txt"), 0, None);
+    //     let hidden = FileEntry::new(OsString::from(".hidden"), FileEntry::IS_HIDDEN, None);
+    //     let system = FileEntry::new(OsString::from("system.sys"), FileEntry::IS_SYSTEM, None);
+    //     let symlink = FileEntry::new(
+    //         OsString::from("symlink"),
+    //         FileEntry::IS_SYMLINK,
+    //         Some(Path::new("target").to_path_buf()),
+    //     );
+    //
+    //     let mut entries = vec![
+    //         normal.clone(),
+    //         hidden.clone(),
+    //         system.clone(),
+    //         symlink.clone(),
+    //     ];
+    //
+    //     let fmt = Formatter::new(true, false, false, false, false, Arc::new(HashSet::new()));
+    //     fmt.filter_entries(&mut entries);
+    //
+    //     assert_eq!(entries.len(), 1);
+    //     assert_eq!(entries[0].name_str(), "normal.txt");
+    //
+    //     let mut entries = vec![
+    //         normal.clone(),
+    //         hidden.clone(),
+    //         system.clone(),
+    //         symlink.clone(),
+    //     ];
+    //
+    //     let fmt = Formatter::new(true, true, true, true, false, Arc::new(HashSet::new()));
+    //     fmt.filter_entries(&mut entries);
+    //     assert_eq!(entries.len(), 4);
+    //     assert!(entries.iter().any(|e| e.name_str() == ".hidden"));
+    //     assert!(entries.iter().any(|e| e.name_str() == "system.sys"));
+    //     assert!(entries.iter().any(|e| e.name_str() == "symlink"));
+    //     assert!(entries.iter().any(|e| e.name_str() == "normal.txt"));
+    // }
+    //
     #[test]
     fn core_empty_dir() -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempdir()?;

--- a/src/core/formatter.rs
+++ b/src/core/formatter.rs
@@ -95,38 +95,45 @@ impl Formatter {
     }
 
     /// Sorts the given file entries in place according to the formatter's settings.
-    pub(crate) fn sort_entries(&self, directory_path: &Path, entries: &mut Vec<FileEntry>) {
+    pub(crate) fn sort_entries(
+        &self,
+        directory_path: &Path,
+        entries: &mut Vec<FileEntry>,
+        list_date_format: &str,
+    ) -> Option<Vec<Arc<str>>> {
         match self.sort_config.mode {
             SortMode::Natural | SortMode::Name => {
                 self.sort_by_name(entries);
+                None
             }
             SortMode::Extension => {
                 self.sort_by_extension(entries);
+                None
             }
-            SortMode::Size => {
-                self.sort_by_filesystem_metadata(directory_path, entries, MetadataSortField::Size);
-            }
-            SortMode::Modified => {
-                self.sort_by_filesystem_metadata(
-                    directory_path,
-                    entries,
-                    MetadataSortField::Modified,
-                );
-            }
-            SortMode::Created => {
-                self.sort_by_filesystem_metadata(
-                    directory_path,
-                    entries,
-                    MetadataSortField::Created,
-                );
-            }
-            SortMode::Accessed => {
-                self.sort_by_filesystem_metadata(
-                    directory_path,
-                    entries,
-                    MetadataSortField::Accessed,
-                );
-            }
+            SortMode::Size => Some(self.sort_by_filesystem_metadata(
+                directory_path,
+                entries,
+                MetadataSortField::Size,
+                list_date_format,
+            )),
+            SortMode::Modified => Some(self.sort_by_filesystem_metadata(
+                directory_path,
+                entries,
+                MetadataSortField::Modified,
+                list_date_format,
+            )),
+            SortMode::Created => Some(self.sort_by_filesystem_metadata(
+                directory_path,
+                entries,
+                MetadataSortField::Created,
+                list_date_format,
+            )),
+            SortMode::Accessed => Some(self.sort_by_filesystem_metadata(
+                directory_path,
+                entries,
+                MetadataSortField::Accessed,
+                list_date_format,
+            )),
         }
     }
 
@@ -263,8 +270,12 @@ impl Formatter {
         directory_path: &Path,
         entries: &mut Vec<FileEntry>,
         metadata_sort_field: MetadataSortField,
-    ) {
+        list_date_format: &str,
+    ) -> Vec<Arc<str>> {
+        use crate::core::formatter::{format_file_size, format_file_time};
+
         let mut keys: Vec<(u8, u128, usize)> = Vec::with_capacity(entries.len());
+        let mut column: Vec<Arc<str>> = Vec::with_capacity(entries.len());
 
         for (index, file_entry) in entries.iter().enumerate() {
             let priority = self.prio_for_entry(file_entry);
@@ -272,24 +283,39 @@ impl Formatter {
             let full_path = directory_path.join(file_entry.name());
             let metadata = std::fs::symlink_metadata(&full_path).ok();
 
-            let metadata_key_value: u128 = match metadata_sort_field {
-                MetadataSortField::Size => metadata
-                    .as_ref()
-                    .map(|m| if m.is_file() { m.len() as u128 } else { 0 })
-                    .unwrap_or(0),
+            let (metadata_key_value, display): (u128, Arc<str>) = match metadata_sort_field {
+                MetadataSortField::Size => {
+                    let size = metadata.as_ref().filter(|m| m.is_file()).map(|m| m.len());
+                    let key = size.unwrap_or(0) as u128;
+                    let s = format_file_size(size, file_entry.is_dir());
+                    (key, Arc::from(s))
+                }
 
                 MetadataSortField::Modified => {
-                    system_time_to_key(metadata.as_ref().and_then(|m| m.modified().ok()))
+                    let t = metadata.as_ref().and_then(|m| m.modified().ok());
+                    (
+                        system_time_to_key(t),
+                        Arc::from(format_file_time(t, list_date_format)),
+                    )
                 }
                 MetadataSortField::Created => {
-                    system_time_to_key(metadata.as_ref().and_then(|m| m.created().ok()))
+                    let t = metadata.as_ref().and_then(|m| m.created().ok());
+                    (
+                        system_time_to_key(t),
+                        Arc::from(format_file_time(t, list_date_format)),
+                    )
                 }
                 MetadataSortField::Accessed => {
-                    system_time_to_key(metadata.as_ref().and_then(|m| m.accessed().ok()))
+                    let t = metadata.as_ref().and_then(|m| m.accessed().ok());
+                    (
+                        system_time_to_key(t),
+                        Arc::from(format_file_time(t, list_date_format)),
+                    )
                 }
             };
 
             keys.push((priority, metadata_key_value, index));
+            column.push(display);
         }
 
         let sort_order = self.sort_config.order;
@@ -323,11 +349,18 @@ impl Formatter {
             })
         });
 
+        // Reorder entries and column with the same permutation (no extra work)
         let old_entries = std::mem::take(entries);
+        let old_column = column;
+
         *entries = keys
-            .into_iter()
-            .map(|(_, _, index)| old_entries[index].clone())
+            .iter()
+            .map(|(_, _, idx)| old_entries[*idx].clone())
             .collect();
+
+        keys.into_iter()
+            .map(|(_, _, idx)| old_column[idx].clone())
+            .collect()
     }
 
     pub(crate) fn filter_entries(&self, entries: &mut Vec<FileEntry>) {

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -14,16 +14,74 @@ use crate::core::formatter::{
 
 use crate::config::display::ShowInfoOptions;
 
+use std::collections::HashMap;
 use std::fs::symlink_metadata;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
 
 #[cfg(windows)]
 pub(crate) const PERMS_WIDTH: usize = 5;
 #[cfg(unix)]
 pub(crate) const PERMS_WIDTH: usize = 10;
+
+/// Cached metadata for sorting.
+/// Holds system calls required info only.
+#[derive(Clone, Copy)]
+pub(crate) struct CachedMetaKey {
+    pub(crate) epoch: u64,
+    pub(crate) size: Option<u64>,
+    pub(crate) modified: Option<SystemTime>,
+    pub(crate) created: Option<SystemTime>,
+    pub(crate) accessed: Option<SystemTime>,
+}
+
+static META_SORT_EPOCH: OnceLock<AtomicU64> = OnceLock::new();
+static META_SORT_CACHE: OnceLock<Mutex<HashMap<PathBuf, CachedMetaKey>>> = OnceLock::new();
+
+#[inline]
+fn epoch_atomic() -> &'static AtomicU64 {
+    META_SORT_EPOCH.get_or_init(|| AtomicU64::new(1))
+}
+
+#[inline]
+fn meta_sort_epoch() -> u64 {
+    epoch_atomic().load(Ordering::Relaxed)
+}
+
+pub(crate) fn bump_meta_sort_epoch() {
+    epoch_atomic().fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+fn meta_cache() -> &'static Mutex<HashMap<PathBuf, CachedMetaKey>> {
+    META_SORT_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn get_or_update_cached_meta(path: &Path) -> Option<CachedMetaKey> {
+    let epoch = meta_sort_epoch();
+    let m = meta_cache();
+    let mut cache = m.lock().ok()?;
+
+    match cache.get(path).copied() {
+        Some(c) if c.epoch == epoch => Some(c),
+        _ => {
+            let md = std::fs::symlink_metadata(path).ok();
+            let c = CachedMetaKey {
+                epoch,
+                size: md.as_ref().filter(|m| m.is_file()).map(|m| m.len()),
+                modified: md.as_ref().and_then(|m| m.modified().ok()),
+                created: md.as_ref().and_then(|m| m.created().ok()),
+                accessed: md.as_ref().and_then(|m| m.accessed().ok()),
+            };
+            cache.insert(path.to_path_buf(), c);
+            Some(c)
+        }
+    }
+}
 
 /// Enumerator for the filye types which are then shown inside [FileMetadata]
 ///

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -17,7 +17,8 @@ use crate::app::nav::SortConfig;
 use crate::config::display::PreviewMethod;
 use crate::core::metadata::{FileMetadata, FileMetadataCache, MetadataNeeds};
 use crate::core::{
-    FileEntry, FindResult, Formatter, browse_dir, find, formatter::safe_read_preview, preview_bat,
+    FileEntry, FindResult, Formatter, browse_dir, find, formatter::DirListOptions,
+    formatter::safe_read_preview, preview_bat,
 };
 use crate::utils::{
     copy_recursive, get_unused_path, is_preview_deny, is_regular_file, merge_dir,
@@ -127,11 +128,7 @@ pub(crate) enum WorkerTask {
     LoadDirectory {
         path: PathBuf,
         focus: Option<OsString>,
-        dirs_first: bool,
-        show_hidden: bool,
-        show_symlink: bool,
-        show_system: bool,
-        case_insensitive: bool,
+        list: DirListOptions,
         sort_config: SortConfig,
         list_date_format: Arc<str>,
         always_show: Arc<HashSet<OsString>>,
@@ -242,11 +239,7 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
             let WorkerTask::LoadDirectory {
                 path,
                 focus,
-                dirs_first,
-                show_hidden,
-                show_symlink,
-                show_system,
-                case_insensitive,
+                list,
                 sort_config,
                 list_date_format,
                 always_show,
@@ -258,15 +251,7 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
             };
             match browse_dir(&path) {
                 Ok(mut entries) => {
-                    let formatter = Formatter::new(
-                        dirs_first,
-                        show_hidden,
-                        show_symlink,
-                        show_system,
-                        case_insensitive,
-                        sort_config,
-                        always_show,
-                    );
+                    let formatter = Formatter::new(list, sort_config, always_show);
                     formatter.filter_entries(&mut entries);
                     let sort_column =
                         formatter.sort_entries(&path, &mut entries, &list_date_format);
@@ -671,226 +656,237 @@ mod tests {
         which::which("bat").is_ok()
     }
 
-    // #[test]
-    // fn worker_pool_full_integration() -> Result<(), Box<dyn std::error::Error>> {
-    //     let workers = Workers::spawn();
-    //     let temp = tempdir()?;
-    //     let test_file = temp.path().join("pool_test.txt");
-    //     fs::write(&test_file, "Hello Pool")?;
-    //
-    //     let find_cancel = Arc::new(AtomicBool::new(false));
-    //     workers.find_tx().send(WorkerTask::FindRecursive {
-    //         base_dir: temp.path().to_path_buf(),
-    //         query: "pool".to_string(),
-    //         max_results: 1,
-    //         cancel: find_cancel,
-    //         show_hidden: false,
-    //         request_id: 10,
-    //         tab_id: TEST_TAB_ID,
-    //     })?;
-    //
-    //     workers.preview_file_tx().send(WorkerTask::LoadPreview {
-    //         path: test_file.clone(),
-    //         max_lines: 1,
-    //         pane_width: 10,
-    //         preview_method: PreviewMethod::Internal,
-    //         args: vec![],
-    //         request_id: 20,
-    //         tab_id: TEST_TAB_ID,
-    //     })?;
-    //
-    //     workers.nav_io_tx().send(WorkerTask::LoadDirectory {
-    //         path: temp.path().to_path_buf(),
-    //         focus: None,
-    //         dirs_first: true,
-    //         show_hidden: false,
-    //         show_symlink: false,
-    //         show_system: false,
-    //         case_insensitive: true,
-    //         always_show: Arc::new(HashSet::new()),
-    //         request_id: 30,
-    //         tab_id: TEST_TAB_ID,
-    //     })?;
-    //
-    //     workers.fileop_tx().send(WorkerTask::FileOp {
-    //         op: FileOperation::Create {
-    //             path: temp.path().join("new_file.txt"),
-    //             is_dir: false,
-    //             overwrite: false,
-    //         },
-    //     })?;
-    //
-    //     let mut responses_collected = 0;
-    //     let mut results_found = false;
-    //     let mut preview_found = false;
-    //     let mut dir_found = false;
-    //     let mut op_found = false;
-    //
-    //     let timeout = Instant::now() + TEST_TIMEOUT;
-    //
-    //     while responses_collected < 4 && Instant::now() < timeout {
-    //         if let Ok(resp) = workers
-    //             .response_rx()
-    //             .recv_timeout(Duration::from_millis(500))
-    //         {
-    //             match resp {
-    //                 WorkerResponse::FindResults { request_id, .. } => {
-    //                     assert_eq!(request_id, 10);
-    //                     results_found = true;
-    //                 }
-    //                 WorkerResponse::PreviewLoaded { request_id, .. } => {
-    //                     assert_eq!(request_id, 20);
-    //                     preview_found = true;
-    //                 }
-    //                 WorkerResponse::DirectoryLoaded { request_id, .. } => {
-    //                     assert_eq!(request_id, 30);
-    //                     dir_found = true;
-    //                 }
-    //                 WorkerResponse::OperationComplete { .. } => {
-    //                     op_found = true;
-    //                 }
-    //                 _ => {}
-    //             }
-    //             responses_collected += 1;
-    //         }
-    //     }
-    //
-    //     assert!(results_found, "Find worker failed");
-    //     assert!(preview_found, "Preview worker failed");
-    //     assert!(dir_found, "Nav IO worker failed");
-    //     assert!(op_found, "FileOp worker failed");
-    //     assert_eq!(responses_collected, 4);
-    //
-    //     Ok(())
-    // }
+    fn test_list_opts() -> DirListOptions {
+        DirListOptions {
+            dirs_first: true,
+            show_hidden: false,
+            show_symlink: false,
+            show_system: false,
+            case_insensitive: true,
+        }
+    }
 
-    // #[test]
-    // fn worker_load_current_dir() -> Result<(), Box<dyn std::error::Error>> {
-    //     let workers = Workers::spawn();
-    //     let temp = tempdir()?;
-    //     let task_tx = workers.nav_io_tx();
-    //     let res_rx = workers.response_rx();
-    //
-    //     let temp_path = temp.path().join("test_dir");
-    //     fs::create_dir(&temp_path)?;
-    //     fs::File::create(temp_path.join("crab.txt"))?;
-    //
-    //     task_tx.send(WorkerTask::LoadDirectory {
-    //         path: temp_path,
-    //         focus: None,
-    //         dirs_first: true,
-    //         show_hidden: false,
-    //         show_symlink: false,
-    //         show_system: false,
-    //         case_insensitive: true,
-    //         always_show: Arc::new(HashSet::new()),
-    //         request_id: 1,
-    //         tab_id: TEST_TAB_ID,
-    //     })?;
-    //
-    //     match res_rx.recv()? {
-    //         WorkerResponse::DirectoryLoaded { entries, .. } => {
-    //             assert!(!entries.is_empty(), "Current dir should not be empty");
-    //
-    //             // Check display name width
-    //             for entry in entries {
-    //                 assert!(!entry.name_str().is_empty());
-    //             }
-    //         }
-    //         WorkerResponse::Error(e, None) => panic!("Worker error: {}", e),
-    //         _ => panic!("Unexpected worker response"),
-    //     }
-    //     Ok(())
-    // }
-    //
-    // #[test]
-    // fn worker_dir_load_requests_multithreaded() -> Result<(), Box<dyn std::error::Error>> {
-    //     let temp_root = tempdir()?;
-    //
-    //     let dir_a = temp_root.path().join("dir_a");
-    //     let dir_b = temp_root.path().join("dir_b");
-    //     fs::create_dir(&dir_a)?;
-    //     fs::create_dir(&dir_b)?;
-    //     fs::write(dir_a.join("file.txt"), "content")?;
-    //
-    //     let dirs = vec![temp_root.path().to_path_buf(), dir_a, dir_b];
-    //
-    //     let thread_count = 2;
-    //     let requests_per_thread = 25;
-    //
-    //     let workers = Workers::spawn();
-    //     let task_tx = workers.nav_io_tx();
-    //     let res_rx = workers.response_rx();
-    //
-    //     // Spawn threads to send requests in parallel
-    //     let mut handles = Vec::new();
-    //     for t in 0..thread_count {
-    //         let task_tx = task_tx.clone();
-    //         let dirs = dirs.clone();
-    //         handles.push(thread::spawn(move || {
-    //             let mut rng = rng();
-    //             for i in 0..requests_per_thread {
-    //                 let dir = &dirs[rng.random_range(0..dirs.len())];
-    //                 task_tx
-    //                     .send(WorkerTask::LoadDirectory {
-    //                         path: dir.clone(),
-    //                         focus: None,
-    //                         dirs_first: rng.random_bool(0.5),
-    //                         show_hidden: rng.random_bool(0.5),
-    //                         show_symlink: rng.random_bool(0.5),
-    //                         show_system: rng.random_bool(0.5),
-    //                         case_insensitive: rng.random_bool(0.5),
-    //                         always_show: Arc::new(HashSet::new()),
-    //                         request_id: (t * requests_per_thread + i) as u64,
-    //                         tab_id: TEST_TAB_ID,
-    //                     })
-    //                     .expect("Couldn't send task to worker");
-    //                 if i % 50 == 0 {
-    //                     thread::sleep(Duration::from_millis(rng.random_range(0..10)));
-    //                 }
-    //             }
-    //         }));
-    //     }
-    //
-    //     // Wait for all senders to finish
-    //     for h in handles {
-    //         if let Err(err) = h.join() {
-    //             panic!("Thread panicked during stress test: {:?}", err);
-    //         }
-    //     }
-    //
-    //     // Read responses
-    //     let total_requests = thread_count * requests_per_thread;
-    //     let mut valid_responses = 0;
-    //     let timeout = Instant::now() + TEST_TIMEOUT;
-    //
-    //     for _ in 0..total_requests {
-    //         let remaining = timeout.saturating_duration_since(Instant::now());
-    //         match res_rx.recv_timeout(remaining.min(Duration::from_millis(500))) {
-    //             Ok(WorkerResponse::DirectoryLoaded { entries, .. }) => {
-    //                 valid_responses += 1;
-    //                 for entry in &entries {
-    //                     let name = entry.name_str();
-    //
-    //                     assert!(!name.is_empty(), "Entry name_str must not be empty.");
-    //                     assert!(
-    //                         !name.contains('\0'),
-    //                         "Entry name_str must not contain null."
-    //                     );
-    //                 }
-    //             }
-    //             Ok(WorkerResponse::Error(e, None)) => panic!("Worker error: {}", e),
-    //             Ok(_) => {}
-    //             Err(_) => break,
-    //         }
-    //     }
-    //
-    //     assert_eq!(
-    //         valid_responses, total_requests,
-    //         "Not all worker requests returned results!"
-    //     );
-    //     Ok(())
-    // }
+    #[test]
+    fn worker_pool_full_integration() -> Result<(), Box<dyn std::error::Error>> {
+        let workers = Workers::spawn();
+        let temp = tempdir()?;
+        let test_file = temp.path().join("pool_test.txt");
+        fs::write(&test_file, "Hello Pool")?;
+
+        let find_cancel = Arc::new(AtomicBool::new(false));
+        workers.find_tx().send(WorkerTask::FindRecursive {
+            base_dir: temp.path().to_path_buf(),
+            query: "pool".to_string(),
+            max_results: 1,
+            cancel: find_cancel,
+            show_hidden: false,
+            request_id: 10,
+            tab_id: TEST_TAB_ID,
+        })?;
+
+        workers.preview_file_tx().send(WorkerTask::LoadPreview {
+            path: test_file.clone(),
+            max_lines: 1,
+            pane_width: 10,
+            preview_method: PreviewMethod::Internal,
+            args: vec![],
+            request_id: 20,
+            tab_id: TEST_TAB_ID,
+        })?;
+
+        workers.nav_io_tx().send(WorkerTask::LoadDirectory {
+            path: temp.path().to_path_buf(),
+            focus: None,
+            list: test_list_opts(),
+            list_date_format: Arc::<str>::from(""),
+            sort_config: SortConfig::default(),
+            always_show: Arc::new(HashSet::new()),
+            request_id: 30,
+            tab_id: TEST_TAB_ID,
+        })?;
+
+        workers.fileop_tx().send(WorkerTask::FileOp {
+            op: FileOperation::Create {
+                path: temp.path().join("new_file.txt"),
+                is_dir: false,
+                overwrite: false,
+            },
+        })?;
+
+        let mut responses_collected = 0;
+        let mut results_found = false;
+        let mut preview_found = false;
+        let mut dir_found = false;
+        let mut op_found = false;
+
+        let timeout = Instant::now() + TEST_TIMEOUT;
+
+        while responses_collected < 4 && Instant::now() < timeout {
+            if let Ok(resp) = workers
+                .response_rx()
+                .recv_timeout(Duration::from_millis(500))
+            {
+                match resp {
+                    WorkerResponse::FindResults { request_id, .. } => {
+                        assert_eq!(request_id, 10);
+                        results_found = true;
+                    }
+                    WorkerResponse::PreviewLoaded { request_id, .. } => {
+                        assert_eq!(request_id, 20);
+                        preview_found = true;
+                    }
+                    WorkerResponse::DirectoryLoaded { request_id, .. } => {
+                        assert_eq!(request_id, 30);
+                        dir_found = true;
+                    }
+                    WorkerResponse::OperationComplete { .. } => {
+                        op_found = true;
+                    }
+                    _ => {}
+                }
+                responses_collected += 1;
+            }
+        }
+
+        assert!(results_found, "Find worker failed");
+        assert!(preview_found, "Preview worker failed");
+        assert!(dir_found, "Nav IO worker failed");
+        assert!(op_found, "FileOp worker failed");
+        assert_eq!(responses_collected, 4);
+
+        Ok(())
+    }
+
+    #[test]
+    fn worker_load_current_dir() -> Result<(), Box<dyn std::error::Error>> {
+        let workers = Workers::spawn();
+        let temp = tempdir()?;
+        let task_tx = workers.nav_io_tx();
+        let res_rx = workers.response_rx();
+
+        let temp_path = temp.path().join("test_dir");
+        fs::create_dir(&temp_path)?;
+        fs::File::create(temp_path.join("crab.txt"))?;
+
+        task_tx.send(WorkerTask::LoadDirectory {
+            path: temp_path,
+            focus: None,
+            list: test_list_opts(),
+            list_date_format: Arc::<str>::from(""),
+            sort_config: SortConfig::default(),
+            always_show: Arc::new(HashSet::new()),
+            request_id: 1,
+            tab_id: TEST_TAB_ID,
+        })?;
+
+        match res_rx.recv()? {
+            WorkerResponse::DirectoryLoaded { entries, .. } => {
+                assert!(!entries.is_empty(), "Current dir should not be empty");
+
+                // Check display name width
+                for entry in entries {
+                    assert!(!entry.name_str().is_empty());
+                }
+            }
+            WorkerResponse::Error(e, None) => panic!("Worker error: {}", e),
+            _ => panic!("Unexpected worker response"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn worker_dir_load_requests_multithreaded() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_root = tempdir()?;
+
+        let dir_a = temp_root.path().join("dir_a");
+        let dir_b = temp_root.path().join("dir_b");
+        fs::create_dir(&dir_a)?;
+        fs::create_dir(&dir_b)?;
+        fs::write(dir_a.join("file.txt"), "content")?;
+
+        let dirs = vec![temp_root.path().to_path_buf(), dir_a, dir_b];
+
+        let thread_count = 2;
+        let requests_per_thread = 25;
+
+        let workers = Workers::spawn();
+        let task_tx = workers.nav_io_tx();
+        let res_rx = workers.response_rx();
+
+        // Spawn threads to send requests in parallel
+        let mut handles = Vec::new();
+        for t in 0..thread_count {
+            let task_tx = task_tx.clone();
+            let dirs = dirs.clone();
+            handles.push(thread::spawn(move || {
+                let mut rng = rng();
+                for i in 0..requests_per_thread {
+                    let dir = &dirs[rng.random_range(0..dirs.len())];
+                    let list = DirListOptions {
+                        dirs_first: rng.random_bool(0.5),
+                        show_hidden: rng.random_bool(0.5),
+                        show_symlink: rng.random_bool(0.5),
+                        show_system: rng.random_bool(0.5),
+                        case_insensitive: rng.random_bool(0.5),
+                    };
+                    task_tx
+                        .send(WorkerTask::LoadDirectory {
+                            path: dir.clone(),
+                            focus: None,
+                            list,
+                            sort_config: SortConfig::default(),
+                            list_date_format: Arc::<str>::from(""),
+                            always_show: Arc::new(HashSet::new()),
+                            request_id: (t * requests_per_thread + i) as u64,
+                            tab_id: TEST_TAB_ID,
+                        })
+                        .expect("Couldn't send task to worker");
+                    if i % 50 == 0 {
+                        thread::sleep(Duration::from_millis(rng.random_range(0..10)));
+                    }
+                }
+            }));
+        }
+
+        // Wait for all senders to finish
+        for h in handles {
+            if let Err(err) = h.join() {
+                panic!("Thread panicked during stress test: {:?}", err);
+            }
+        }
+
+        // Read responses
+        let total_requests = thread_count * requests_per_thread;
+        let mut valid_responses = 0;
+        let timeout = Instant::now() + TEST_TIMEOUT;
+
+        for _ in 0..total_requests {
+            let remaining = timeout.saturating_duration_since(Instant::now());
+            match res_rx.recv_timeout(remaining.min(Duration::from_millis(500))) {
+                Ok(WorkerResponse::DirectoryLoaded { entries, .. }) => {
+                    valid_responses += 1;
+                    for entry in &entries {
+                        let name = entry.name_str();
+
+                        assert!(!name.is_empty(), "Entry name_str must not be empty.");
+                        assert!(
+                            !name.contains('\0'),
+                            "Entry name_str must not contain null."
+                        );
+                    }
+                }
+                Ok(WorkerResponse::Error(e, None)) => panic!("Worker error: {}", e),
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+
+        assert_eq!(
+            valid_responses, total_requests,
+            "Not all worker requests returned results!"
+        );
+        Ok(())
+    }
 
     #[test]
     fn worker_find_pool() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -15,7 +15,7 @@
 
 use crate::app::nav::SortConfig;
 use crate::config::display::PreviewMethod;
-use crate::core::metadata::{FileMetadata, FileMetadataCache, MetadataNeeds};
+use crate::core::metadata::{FileMetadata, FileMetadataCache, MetadataNeeds, bump_meta_sort_epoch};
 use crate::core::{
     FileEntry, FindResult, Formatter, browse_dir, find, formatter::DirListOptions,
     formatter::safe_read_preview, preview_bat,
@@ -629,6 +629,7 @@ fn start_fileop_worker(
 
             match result {
                 Ok(_) => {
+                    bump_meta_sort_epoch();
                     let _ = res_tx.send(WorkerResponse::OperationComplete {
                         need_reload: true,
                         focus: focus_target,
@@ -681,13 +682,6 @@ fn start_metadata_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerRes
             }
         }
     });
-}
-
-fn _assert_send_sync<T: Send + Sync>() {}
-fn _assert_thread_safety() {
-    _assert_send_sync::<DirListOptions>();
-    _assert_send_sync::<SortConfig>();
-    _assert_send_sync::<crate::core::formatter::Formatter>();
 }
 
 /// Worker threads integration tests.

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -13,6 +13,7 @@
 //! This module is a central protocol boundary. Small changes (adding or editing variants, fields, or error handling)
 //! may require corresponding changes throughout state, response-handling code and UI.
 
+use crate::app::nav::SortConfig;
 use crate::config::display::PreviewMethod;
 use crate::core::metadata::{FileMetadata, FileMetadataCache, MetadataNeeds};
 use crate::core::{
@@ -131,6 +132,7 @@ pub(crate) enum WorkerTask {
         show_symlink: bool,
         show_system: bool,
         case_insensitive: bool,
+        sort_config: SortConfig,
         always_show: Arc<HashSet<OsString>>,
         request_id: u64,
         tab_id: Option<usize>,
@@ -243,6 +245,7 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
                 show_symlink,
                 show_system,
                 case_insensitive,
+                sort_config,
                 always_show,
                 request_id,
                 tab_id,
@@ -258,10 +261,11 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
                         show_symlink,
                         show_system,
                         case_insensitive,
+                        sort_config,
                         always_show,
                     );
                     formatter.filter_entries(&mut entries);
-                    formatter.sort_entries(&mut entries);
+                    formatter.sort_entries(&path, &mut entries);
                     let _ = res_tx.send(WorkerResponse::DirectoryLoaded {
                         path,
                         entries,
@@ -662,226 +666,226 @@ mod tests {
         which::which("bat").is_ok()
     }
 
-    #[test]
-    fn worker_pool_full_integration() -> Result<(), Box<dyn std::error::Error>> {
-        let workers = Workers::spawn();
-        let temp = tempdir()?;
-        let test_file = temp.path().join("pool_test.txt");
-        fs::write(&test_file, "Hello Pool")?;
+    // #[test]
+    // fn worker_pool_full_integration() -> Result<(), Box<dyn std::error::Error>> {
+    //     let workers = Workers::spawn();
+    //     let temp = tempdir()?;
+    //     let test_file = temp.path().join("pool_test.txt");
+    //     fs::write(&test_file, "Hello Pool")?;
+    //
+    //     let find_cancel = Arc::new(AtomicBool::new(false));
+    //     workers.find_tx().send(WorkerTask::FindRecursive {
+    //         base_dir: temp.path().to_path_buf(),
+    //         query: "pool".to_string(),
+    //         max_results: 1,
+    //         cancel: find_cancel,
+    //         show_hidden: false,
+    //         request_id: 10,
+    //         tab_id: TEST_TAB_ID,
+    //     })?;
+    //
+    //     workers.preview_file_tx().send(WorkerTask::LoadPreview {
+    //         path: test_file.clone(),
+    //         max_lines: 1,
+    //         pane_width: 10,
+    //         preview_method: PreviewMethod::Internal,
+    //         args: vec![],
+    //         request_id: 20,
+    //         tab_id: TEST_TAB_ID,
+    //     })?;
+    //
+    //     workers.nav_io_tx().send(WorkerTask::LoadDirectory {
+    //         path: temp.path().to_path_buf(),
+    //         focus: None,
+    //         dirs_first: true,
+    //         show_hidden: false,
+    //         show_symlink: false,
+    //         show_system: false,
+    //         case_insensitive: true,
+    //         always_show: Arc::new(HashSet::new()),
+    //         request_id: 30,
+    //         tab_id: TEST_TAB_ID,
+    //     })?;
+    //
+    //     workers.fileop_tx().send(WorkerTask::FileOp {
+    //         op: FileOperation::Create {
+    //             path: temp.path().join("new_file.txt"),
+    //             is_dir: false,
+    //             overwrite: false,
+    //         },
+    //     })?;
+    //
+    //     let mut responses_collected = 0;
+    //     let mut results_found = false;
+    //     let mut preview_found = false;
+    //     let mut dir_found = false;
+    //     let mut op_found = false;
+    //
+    //     let timeout = Instant::now() + TEST_TIMEOUT;
+    //
+    //     while responses_collected < 4 && Instant::now() < timeout {
+    //         if let Ok(resp) = workers
+    //             .response_rx()
+    //             .recv_timeout(Duration::from_millis(500))
+    //         {
+    //             match resp {
+    //                 WorkerResponse::FindResults { request_id, .. } => {
+    //                     assert_eq!(request_id, 10);
+    //                     results_found = true;
+    //                 }
+    //                 WorkerResponse::PreviewLoaded { request_id, .. } => {
+    //                     assert_eq!(request_id, 20);
+    //                     preview_found = true;
+    //                 }
+    //                 WorkerResponse::DirectoryLoaded { request_id, .. } => {
+    //                     assert_eq!(request_id, 30);
+    //                     dir_found = true;
+    //                 }
+    //                 WorkerResponse::OperationComplete { .. } => {
+    //                     op_found = true;
+    //                 }
+    //                 _ => {}
+    //             }
+    //             responses_collected += 1;
+    //         }
+    //     }
+    //
+    //     assert!(results_found, "Find worker failed");
+    //     assert!(preview_found, "Preview worker failed");
+    //     assert!(dir_found, "Nav IO worker failed");
+    //     assert!(op_found, "FileOp worker failed");
+    //     assert_eq!(responses_collected, 4);
+    //
+    //     Ok(())
+    // }
 
-        let find_cancel = Arc::new(AtomicBool::new(false));
-        workers.find_tx().send(WorkerTask::FindRecursive {
-            base_dir: temp.path().to_path_buf(),
-            query: "pool".to_string(),
-            max_results: 1,
-            cancel: find_cancel,
-            show_hidden: false,
-            request_id: 10,
-            tab_id: TEST_TAB_ID,
-        })?;
-
-        workers.preview_file_tx().send(WorkerTask::LoadPreview {
-            path: test_file.clone(),
-            max_lines: 1,
-            pane_width: 10,
-            preview_method: PreviewMethod::Internal,
-            args: vec![],
-            request_id: 20,
-            tab_id: TEST_TAB_ID,
-        })?;
-
-        workers.nav_io_tx().send(WorkerTask::LoadDirectory {
-            path: temp.path().to_path_buf(),
-            focus: None,
-            dirs_first: true,
-            show_hidden: false,
-            show_symlink: false,
-            show_system: false,
-            case_insensitive: true,
-            always_show: Arc::new(HashSet::new()),
-            request_id: 30,
-            tab_id: TEST_TAB_ID,
-        })?;
-
-        workers.fileop_tx().send(WorkerTask::FileOp {
-            op: FileOperation::Create {
-                path: temp.path().join("new_file.txt"),
-                is_dir: false,
-                overwrite: false,
-            },
-        })?;
-
-        let mut responses_collected = 0;
-        let mut results_found = false;
-        let mut preview_found = false;
-        let mut dir_found = false;
-        let mut op_found = false;
-
-        let timeout = Instant::now() + TEST_TIMEOUT;
-
-        while responses_collected < 4 && Instant::now() < timeout {
-            if let Ok(resp) = workers
-                .response_rx()
-                .recv_timeout(Duration::from_millis(500))
-            {
-                match resp {
-                    WorkerResponse::FindResults { request_id, .. } => {
-                        assert_eq!(request_id, 10);
-                        results_found = true;
-                    }
-                    WorkerResponse::PreviewLoaded { request_id, .. } => {
-                        assert_eq!(request_id, 20);
-                        preview_found = true;
-                    }
-                    WorkerResponse::DirectoryLoaded { request_id, .. } => {
-                        assert_eq!(request_id, 30);
-                        dir_found = true;
-                    }
-                    WorkerResponse::OperationComplete { .. } => {
-                        op_found = true;
-                    }
-                    _ => {}
-                }
-                responses_collected += 1;
-            }
-        }
-
-        assert!(results_found, "Find worker failed");
-        assert!(preview_found, "Preview worker failed");
-        assert!(dir_found, "Nav IO worker failed");
-        assert!(op_found, "FileOp worker failed");
-        assert_eq!(responses_collected, 4);
-
-        Ok(())
-    }
-
-    #[test]
-    fn worker_load_current_dir() -> Result<(), Box<dyn std::error::Error>> {
-        let workers = Workers::spawn();
-        let temp = tempdir()?;
-        let task_tx = workers.nav_io_tx();
-        let res_rx = workers.response_rx();
-
-        let temp_path = temp.path().join("test_dir");
-        fs::create_dir(&temp_path)?;
-        fs::File::create(temp_path.join("crab.txt"))?;
-
-        task_tx.send(WorkerTask::LoadDirectory {
-            path: temp_path,
-            focus: None,
-            dirs_first: true,
-            show_hidden: false,
-            show_symlink: false,
-            show_system: false,
-            case_insensitive: true,
-            always_show: Arc::new(HashSet::new()),
-            request_id: 1,
-            tab_id: TEST_TAB_ID,
-        })?;
-
-        match res_rx.recv()? {
-            WorkerResponse::DirectoryLoaded { entries, .. } => {
-                assert!(!entries.is_empty(), "Current dir should not be empty");
-
-                // Check display name width
-                for entry in entries {
-                    assert!(!entry.name_str().is_empty());
-                }
-            }
-            WorkerResponse::Error(e, None) => panic!("Worker error: {}", e),
-            _ => panic!("Unexpected worker response"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn worker_dir_load_requests_multithreaded() -> Result<(), Box<dyn std::error::Error>> {
-        let temp_root = tempdir()?;
-
-        let dir_a = temp_root.path().join("dir_a");
-        let dir_b = temp_root.path().join("dir_b");
-        fs::create_dir(&dir_a)?;
-        fs::create_dir(&dir_b)?;
-        fs::write(dir_a.join("file.txt"), "content")?;
-
-        let dirs = vec![temp_root.path().to_path_buf(), dir_a, dir_b];
-
-        let thread_count = 2;
-        let requests_per_thread = 25;
-
-        let workers = Workers::spawn();
-        let task_tx = workers.nav_io_tx();
-        let res_rx = workers.response_rx();
-
-        // Spawn threads to send requests in parallel
-        let mut handles = Vec::new();
-        for t in 0..thread_count {
-            let task_tx = task_tx.clone();
-            let dirs = dirs.clone();
-            handles.push(thread::spawn(move || {
-                let mut rng = rng();
-                for i in 0..requests_per_thread {
-                    let dir = &dirs[rng.random_range(0..dirs.len())];
-                    task_tx
-                        .send(WorkerTask::LoadDirectory {
-                            path: dir.clone(),
-                            focus: None,
-                            dirs_first: rng.random_bool(0.5),
-                            show_hidden: rng.random_bool(0.5),
-                            show_symlink: rng.random_bool(0.5),
-                            show_system: rng.random_bool(0.5),
-                            case_insensitive: rng.random_bool(0.5),
-                            always_show: Arc::new(HashSet::new()),
-                            request_id: (t * requests_per_thread + i) as u64,
-                            tab_id: TEST_TAB_ID,
-                        })
-                        .expect("Couldn't send task to worker");
-                    if i % 50 == 0 {
-                        thread::sleep(Duration::from_millis(rng.random_range(0..10)));
-                    }
-                }
-            }));
-        }
-
-        // Wait for all senders to finish
-        for h in handles {
-            if let Err(err) = h.join() {
-                panic!("Thread panicked during stress test: {:?}", err);
-            }
-        }
-
-        // Read responses
-        let total_requests = thread_count * requests_per_thread;
-        let mut valid_responses = 0;
-        let timeout = Instant::now() + TEST_TIMEOUT;
-
-        for _ in 0..total_requests {
-            let remaining = timeout.saturating_duration_since(Instant::now());
-            match res_rx.recv_timeout(remaining.min(Duration::from_millis(500))) {
-                Ok(WorkerResponse::DirectoryLoaded { entries, .. }) => {
-                    valid_responses += 1;
-                    for entry in &entries {
-                        let name = entry.name_str();
-
-                        assert!(!name.is_empty(), "Entry name_str must not be empty.");
-                        assert!(
-                            !name.contains('\0'),
-                            "Entry name_str must not contain null."
-                        );
-                    }
-                }
-                Ok(WorkerResponse::Error(e, None)) => panic!("Worker error: {}", e),
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert_eq!(
-            valid_responses, total_requests,
-            "Not all worker requests returned results!"
-        );
-        Ok(())
-    }
+    // #[test]
+    // fn worker_load_current_dir() -> Result<(), Box<dyn std::error::Error>> {
+    //     let workers = Workers::spawn();
+    //     let temp = tempdir()?;
+    //     let task_tx = workers.nav_io_tx();
+    //     let res_rx = workers.response_rx();
+    //
+    //     let temp_path = temp.path().join("test_dir");
+    //     fs::create_dir(&temp_path)?;
+    //     fs::File::create(temp_path.join("crab.txt"))?;
+    //
+    //     task_tx.send(WorkerTask::LoadDirectory {
+    //         path: temp_path,
+    //         focus: None,
+    //         dirs_first: true,
+    //         show_hidden: false,
+    //         show_symlink: false,
+    //         show_system: false,
+    //         case_insensitive: true,
+    //         always_show: Arc::new(HashSet::new()),
+    //         request_id: 1,
+    //         tab_id: TEST_TAB_ID,
+    //     })?;
+    //
+    //     match res_rx.recv()? {
+    //         WorkerResponse::DirectoryLoaded { entries, .. } => {
+    //             assert!(!entries.is_empty(), "Current dir should not be empty");
+    //
+    //             // Check display name width
+    //             for entry in entries {
+    //                 assert!(!entry.name_str().is_empty());
+    //             }
+    //         }
+    //         WorkerResponse::Error(e, None) => panic!("Worker error: {}", e),
+    //         _ => panic!("Unexpected worker response"),
+    //     }
+    //     Ok(())
+    // }
+    //
+    // #[test]
+    // fn worker_dir_load_requests_multithreaded() -> Result<(), Box<dyn std::error::Error>> {
+    //     let temp_root = tempdir()?;
+    //
+    //     let dir_a = temp_root.path().join("dir_a");
+    //     let dir_b = temp_root.path().join("dir_b");
+    //     fs::create_dir(&dir_a)?;
+    //     fs::create_dir(&dir_b)?;
+    //     fs::write(dir_a.join("file.txt"), "content")?;
+    //
+    //     let dirs = vec![temp_root.path().to_path_buf(), dir_a, dir_b];
+    //
+    //     let thread_count = 2;
+    //     let requests_per_thread = 25;
+    //
+    //     let workers = Workers::spawn();
+    //     let task_tx = workers.nav_io_tx();
+    //     let res_rx = workers.response_rx();
+    //
+    //     // Spawn threads to send requests in parallel
+    //     let mut handles = Vec::new();
+    //     for t in 0..thread_count {
+    //         let task_tx = task_tx.clone();
+    //         let dirs = dirs.clone();
+    //         handles.push(thread::spawn(move || {
+    //             let mut rng = rng();
+    //             for i in 0..requests_per_thread {
+    //                 let dir = &dirs[rng.random_range(0..dirs.len())];
+    //                 task_tx
+    //                     .send(WorkerTask::LoadDirectory {
+    //                         path: dir.clone(),
+    //                         focus: None,
+    //                         dirs_first: rng.random_bool(0.5),
+    //                         show_hidden: rng.random_bool(0.5),
+    //                         show_symlink: rng.random_bool(0.5),
+    //                         show_system: rng.random_bool(0.5),
+    //                         case_insensitive: rng.random_bool(0.5),
+    //                         always_show: Arc::new(HashSet::new()),
+    //                         request_id: (t * requests_per_thread + i) as u64,
+    //                         tab_id: TEST_TAB_ID,
+    //                     })
+    //                     .expect("Couldn't send task to worker");
+    //                 if i % 50 == 0 {
+    //                     thread::sleep(Duration::from_millis(rng.random_range(0..10)));
+    //                 }
+    //             }
+    //         }));
+    //     }
+    //
+    //     // Wait for all senders to finish
+    //     for h in handles {
+    //         if let Err(err) = h.join() {
+    //             panic!("Thread panicked during stress test: {:?}", err);
+    //         }
+    //     }
+    //
+    //     // Read responses
+    //     let total_requests = thread_count * requests_per_thread;
+    //     let mut valid_responses = 0;
+    //     let timeout = Instant::now() + TEST_TIMEOUT;
+    //
+    //     for _ in 0..total_requests {
+    //         let remaining = timeout.saturating_duration_since(Instant::now());
+    //         match res_rx.recv_timeout(remaining.min(Duration::from_millis(500))) {
+    //             Ok(WorkerResponse::DirectoryLoaded { entries, .. }) => {
+    //                 valid_responses += 1;
+    //                 for entry in &entries {
+    //                     let name = entry.name_str();
+    //
+    //                     assert!(!name.is_empty(), "Entry name_str must not be empty.");
+    //                     assert!(
+    //                         !name.contains('\0'),
+    //                         "Entry name_str must not contain null."
+    //                     );
+    //                 }
+    //             }
+    //             Ok(WorkerResponse::Error(e, None)) => panic!("Worker error: {}", e),
+    //             Ok(_) => {}
+    //             Err(_) => break,
+    //         }
+    //     }
+    //
+    //     assert_eq!(
+    //         valid_responses, total_requests,
+    //         "Not all worker requests returned results!"
+    //     );
+    //     Ok(())
+    // }
 
     #[test]
     fn worker_find_pool() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -39,6 +39,7 @@ pub(crate) struct Workers {
     nav_io_tx: Sender<WorkerTask>,
     parent_io_tx: Sender<WorkerTask>,
     preview_io_tx: Sender<WorkerTask>,
+    sort_io_tx: Sender<WorkerTask>,
     preview_file_tx: Sender<WorkerTask>,
     metadata_tx: Sender<WorkerTask>,
     find_tx: Sender<WorkerTask>,
@@ -63,6 +64,8 @@ impl Workers {
         let (nav_io_tx, nav_io_rx) = bounded::<WorkerTask>(1);
         let (parent_io_tx, parent_io_rx) = bounded::<WorkerTask>(1);
         let (preview_io_tx, preview_io_rx) = bounded::<WorkerTask>(1);
+        let (sort_io_tx, sort_io_rx) = bounded::<WorkerTask>(1);
+
         let (preview_file_tx, preview_file_rx) = bounded::<WorkerTask>(1);
         let (metadata_tx, metadata_rx) = bounded::<WorkerTask>(1);
         let (find_tx, find_rx) = bounded::<WorkerTask>(1);
@@ -75,6 +78,8 @@ impl Workers {
         start_io_worker(nav_io_rx, res_tx.clone());
         start_io_worker(parent_io_rx, res_tx.clone());
         start_io_worker(preview_io_rx, res_tx.clone());
+        start_sort_worker(sort_io_rx, res_tx.clone());
+
         start_preview_worker(preview_file_rx, res_tx.clone());
         start_metadata_worker(metadata_rx, res_tx.clone());
         start_find_worker(find_rx, res_tx.clone());
@@ -84,6 +89,7 @@ impl Workers {
             nav_io_tx,
             parent_io_tx,
             preview_io_tx,
+            sort_io_tx,
             preview_file_tx,
             metadata_tx,
             find_tx,
@@ -97,6 +103,7 @@ impl Workers {
         nav_io_tx: &Sender<WorkerTask>,
         parent_io_tx: &Sender<WorkerTask>,
         preview_io_tx: &Sender<WorkerTask>,
+        sort_io_tx: &Sender<WorkerTask>,
         preview_file_tx: &Sender<WorkerTask>,
         metadata_tx: &Sender<WorkerTask>,
         find_tx: &Sender<WorkerTask>,
@@ -127,6 +134,17 @@ impl Drop for ActiveOpGuard {
 pub(crate) enum WorkerTask {
     LoadDirectory {
         path: PathBuf,
+        focus: Option<OsString>,
+        list: DirListOptions,
+        sort_config: SortConfig,
+        list_date_format: Arc<str>,
+        always_show: Arc<HashSet<OsString>>,
+        request_id: u64,
+        tab_id: Option<usize>,
+    },
+    ResortDirectory {
+        path: PathBuf,
+        entries: Vec<FileEntry>,
         focus: Option<OsString>,
         list: DirListOptions,
         sort_config: SortConfig,
@@ -255,6 +273,7 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
                     formatter.filter_entries(&mut entries);
                     let sort_column =
                         formatter.sort_entries(&path, &mut entries, &list_date_format);
+
                     let _ = res_tx.send(WorkerResponse::DirectoryLoaded {
                         path,
                         entries,
@@ -271,6 +290,40 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
                     ));
                 }
             }
+        }
+    });
+}
+
+fn start_sort_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>) {
+    thread::spawn(move || {
+        while let Ok(task) = task_rx.recv() {
+            let WorkerTask::ResortDirectory {
+                path,
+                focus,
+                list,
+                sort_config,
+                list_date_format,
+                always_show,
+                request_id,
+                tab_id,
+                mut entries,
+            } = task
+            else {
+                continue;
+            };
+
+            let formatter = Formatter::new(list, sort_config, always_show);
+            formatter.filter_entries(&mut entries);
+            let sort_column = formatter.sort_entries(&path, &mut entries, &list_date_format);
+
+            let _ = res_tx.send(WorkerResponse::DirectoryLoaded {
+                path,
+                entries,
+                focus,
+                sort_column,
+                request_id,
+                tab_id,
+            });
         }
     });
 }
@@ -628,6 +681,13 @@ fn start_metadata_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerRes
             }
         }
     });
+}
+
+fn _assert_send_sync<T: Send + Sync>() {}
+fn _assert_thread_safety() {
+    _assert_send_sync::<DirListOptions>();
+    _assert_send_sync::<SortConfig>();
+    _assert_send_sync::<crate::core::formatter::Formatter>();
 }
 
 /// Worker threads integration tests.

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -133,6 +133,7 @@ pub(crate) enum WorkerTask {
         show_system: bool,
         case_insensitive: bool,
         sort_config: SortConfig,
+        list_date_format: Arc<str>,
         always_show: Arc<HashSet<OsString>>,
         request_id: u64,
         tab_id: Option<usize>,
@@ -196,6 +197,7 @@ pub(crate) enum WorkerResponse {
         path: PathBuf,
         entries: Vec<FileEntry>,
         focus: Option<OsString>,
+        sort_column: Option<Vec<Arc<str>>>,
         request_id: u64,
         tab_id: Option<usize>,
     },
@@ -246,6 +248,7 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
                 show_system,
                 case_insensitive,
                 sort_config,
+                list_date_format,
                 always_show,
                 request_id,
                 tab_id,
@@ -265,11 +268,13 @@ fn start_io_worker(task_rx: Receiver<WorkerTask>, res_tx: Sender<WorkerResponse>
                         always_show,
                     );
                     formatter.filter_entries(&mut entries);
-                    formatter.sort_entries(&path, &mut entries);
+                    let sort_column =
+                        formatter.sort_entries(&path, &mut entries, &list_date_format);
                     let _ = res_tx.send(WorkerResponse::DirectoryLoaded {
                         path,
                         entries,
                         focus,
+                        sort_column,
                         request_id,
                         tab_id,
                     });

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -21,6 +21,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 const MAX_RIGHT_COLUMN_WIDTH: u16 = 24;
 const MIN_LEFT_WIDTH: u16 = 12;
@@ -91,6 +92,31 @@ pub(crate) struct PaneMarkers<'a> {
     pub(crate) clipboard_style: Style,
 }
 
+#[derive(Clone, Copy)]
+struct RightCol<'a> {
+    text: Option<&'a str>,
+    width: u16,
+}
+
+impl<'a> RightCol<'a> {
+    #[inline]
+    fn none() -> Self {
+        Self {
+            text: None,
+            width: 0,
+        }
+    }
+
+    #[inline]
+    fn reserve(self) -> usize {
+        if self.text.is_some() {
+            self.width as usize + 1
+        } else {
+            0
+        }
+    }
+}
+
 /// Draws the main file list pane in the UI
 ///
 /// Highlights selection, markers and directories and handles styling for items.
@@ -133,7 +159,7 @@ pub(crate) fn draw_main(
 
     let sort_column = app.nav().sort_column();
     let right_w = right_col_width(sort_column.as_ref());
-    let inner_w = context.area.width.saturating_sub(2);
+    let inner_w = context.block.inner(context.area).width;
     let show_col = pane_show_col(inner_w, right_w);
 
     let mut items = Vec::with_capacity(shown_len);
@@ -146,8 +172,18 @@ pub(crate) fn draw_main(
                 .as_ref()
                 .and_then(|c| c.get(abs_idx))
                 .map(|s| s.as_ref())
+                .filter(|s| !s.is_empty())
         } else {
             None
+        };
+
+        let right = if show_col {
+            RightCol {
+                text: right_col,
+                width: right_w,
+            }
+        } else {
+            RightCol::none()
         };
 
         items.push(make_entry_row(
@@ -157,8 +193,7 @@ pub(crate) fn draw_main(
             &context,
             &markers,
             None,
-            right_col,
-            right_w,
+            right,
         ));
     }
 
@@ -248,7 +283,7 @@ pub(crate) fn draw_preview(
             }
 
             let right_w = right_col_width(sort_column.as_ref());
-            let inner_w = context.area.width.saturating_sub(2);
+            let inner_w = context.block.inner(context.area).width;
             let show_col = pane_show_col(inner_w, right_w);
 
             let mut items = Vec::with_capacity(entries.len());
@@ -261,8 +296,18 @@ pub(crate) fn draw_preview(
                         .as_ref()
                         .and_then(|c| c.get(idx))
                         .map(|s| s.as_ref())
+                        .filter(|s| !s.is_empty())
                 } else {
                     None
+                };
+
+                let right = if show_col {
+                    RightCol {
+                        text: right_col,
+                        width: right_w,
+                    }
+                } else {
+                    RightCol::none()
                 };
 
                 items.push(make_entry_row(
@@ -272,8 +317,7 @@ pub(crate) fn draw_preview(
                     &context,
                     markers,
                     Some(&opts),
-                    right_col,
-                    right_w,
+                    right,
                 ));
             }
 
@@ -321,7 +365,7 @@ pub(crate) fn draw_parent(
 
     let sort_column = app.parent().sort_column();
     let right_w = right_col_width(sort_column.as_ref());
-    let inner_w = context.area.width.saturating_sub(2);
+    let inner_w = context.block.inner(context.area).width;
     let show_col = pane_show_col(inner_w, right_w);
 
     let mut items = Vec::with_capacity(entries.len());
@@ -333,9 +377,20 @@ pub(crate) fn draw_parent(
                 .as_ref()
                 .and_then(|c| c.get(idx))
                 .map(|s| s.as_ref())
+                .filter(|s| !s.is_empty())
         } else {
             None
         };
+
+        let right = if show_col {
+            RightCol {
+                text: right_col,
+                width: right_w,
+            }
+        } else {
+            RightCol::none()
+        };
+
         items.push(make_entry_row(
             entry,
             is_selected,
@@ -343,8 +398,7 @@ pub(crate) fn draw_parent(
             &context,
             markers,
             None,
-            right_col,
-            right_w,
+            right,
         ));
     }
 
@@ -464,8 +518,7 @@ fn make_entry_row<'a>(
     context: &PaneContext,
     markers: &PaneMarkers,
     opts: Option<&PreviewOptions>,
-    right_col: Option<&'a str>,
-    right_width: u16,
+    right: RightCol<'a>,
 ) -> ListItem<'a> {
     let mut used_w: usize = 0;
 
@@ -558,12 +611,8 @@ fn make_entry_row<'a>(
         spans.push(Span::styled(icon_col, icon_render_style));
     }
 
-    let total_w = context.area.width.saturating_sub(2) as usize;
-    let reserve = if right_col.is_some() {
-        (right_width as usize) + 1
-    } else {
-        0
-    };
+    let total_w = context.block.inner(context.area).width as usize;
+    let reserve = right.reserve();
 
     let name_raw = entry.name_str();
     let name_budget = total_w
@@ -621,21 +670,19 @@ fn make_entry_row<'a>(
         }
     }
 
-    if let Some(col) = right_col {
-        let total_w = context.area.width.saturating_sub(2) as usize;
-        let col_area_w = right_width as usize;
+    if let Some(col) = right.text {
+        let col_area_w = right.width as usize;
+        let right_text = if UnicodeWidthStr::width(col) <= col_area_w {
+            build_right_field(col, total_w, used_w, col_area_w)
+        } else {
+            let col = truncate_owned(col, col_area_w);
+            build_right_field(&col, total_w, used_w, col_area_w)
+        };
 
-        let pad_spaces = total_w.saturating_sub(used_w + 1 + col_area_w);
-        spans.push(Span::raw(" ".repeat(pad_spaces)));
-        spans.push(Span::raw(" "));
-
-        let col_w = UnicodeWidthStr::width(col).min(col_area_w);
-        let inner_pad = col_area_w.saturating_sub(col_w);
-        if inner_pad > 0 {
-            spans.push(Span::raw(" ".repeat(inner_pad)));
-        }
-
-        spans.push(Span::styled(col, row_style.add_modifier(Modifier::DIM)));
+        spans.push(Span::styled(
+            right_text,
+            row_style.add_modifier(Modifier::DIM),
+        ));
     }
 
     ListItem::new(Line::from(spans)).style(row_style)
@@ -688,4 +735,51 @@ fn truncate_owned(s: &str, max_w: usize) -> String {
 #[inline]
 fn left_remaining(total_w: usize, used_w: usize, reserve: usize) -> usize {
     total_w.saturating_sub(reserve).saturating_sub(used_w)
+}
+
+#[inline]
+fn build_right_field(col: &str, total_w: usize, used_w: usize, col_area_w: usize) -> String {
+    let pad_spaces = total_w.saturating_sub(used_w + 1 + col_area_w);
+
+    let col_w = UnicodeWidthStr::width(col).min(col_area_w);
+    let inner_pad = col_area_w.saturating_sub(col_w);
+
+    let mut out = String::with_capacity(pad_spaces + 1 + inner_pad + col.len());
+    out.extend(std::iter::repeat_n(' ', pad_spaces));
+    out.push(' ');
+    out.extend(std::iter::repeat_n(' ', inner_pad));
+    out.push_str(col);
+    out
+}
+
+fn pane_inner_width(context: &PaneContext) -> u16 {
+    context.block.inner(context.area).width
+}
+
+fn right_col_config<'a>(inner_w: u16, sort_column: Option<&Vec<Arc<str>>>) -> (bool, u16) {
+    let right_w = right_col_width(sort_column);
+    let show_col = pane_show_col(inner_w, right_w);
+    (show_col, right_w)
+}
+
+fn right_col_at<'a>(sort_column: Option<&'a Vec<Arc<str>>>, idx: usize) -> Option<&'a str> {
+    sort_column
+        .and_then(|c| c.get(idx))
+        .map(|s| s.as_ref())
+        .filter(|s| !s.is_empty())
+}
+
+fn right_col_for<'a>(
+    show_col: bool,
+    right_w: u16,
+    sort_column: Option<&'a Vec<Arc<str>>>,
+    idx: usize,
+) -> RightCol<'a> {
+    if !show_col {
+        return RightCol::none();
+    }
+    RightCol {
+        text: right_col_at(sort_column, idx),
+        width: right_w,
+    }
 }

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -158,33 +158,15 @@ pub(crate) fn draw_main(
     let shown_len = app.nav().shown_entries_len();
 
     let sort_column = app.nav().sort_column();
-    let right_w = right_col_width(sort_column.as_ref());
-    let inner_w = context.block.inner(context.area).width;
-    let show_col = pane_show_col(inner_w, right_w);
+    let inner_w = pane_inner_width(&context);
+    let (show_col, right_w) = right_col_config(inner_w, sort_column.as_ref());
 
     let mut items = Vec::with_capacity(shown_len);
     for (vis_idx, &abs_idx) in app.nav().shown_indices().iter().enumerate() {
         let entry = &app.nav().entries()[abs_idx];
         let is_selected = Some(vis_idx) == selected_idx;
         let entry_style = context.styles.get_style(entry.is_dir(), is_selected);
-        let right_col = if show_col {
-            sort_column
-                .as_ref()
-                .and_then(|c| c.get(abs_idx))
-                .map(|s| s.as_ref())
-                .filter(|s| !s.is_empty())
-        } else {
-            None
-        };
-
-        let right = if show_col {
-            RightCol {
-                text: right_col,
-                width: right_w,
-            }
-        } else {
-            RightCol::none()
-        };
+        let right = right_col_for(show_col, right_w, sort_column.as_ref(), abs_idx);
 
         items.push(make_entry_row(
             entry,
@@ -282,33 +264,14 @@ pub(crate) fn draw_preview(
                 return;
             }
 
-            let right_w = right_col_width(sort_column.as_ref());
-            let inner_w = context.block.inner(context.area).width;
-            let show_col = pane_show_col(inner_w, right_w);
+            let inner_w = pane_inner_width(&context);
+            let (show_col, right_w) = right_col_config(inner_w, sort_column.as_ref());
 
             let mut items = Vec::with_capacity(entries.len());
             for (idx, entry) in entries.iter().enumerate() {
                 let is_selected = Some(idx) == selected_idx;
                 let style = context.styles.get_style(entry.is_dir(), is_selected);
-
-                let right_col = if show_col {
-                    sort_column
-                        .as_ref()
-                        .and_then(|c| c.get(idx))
-                        .map(|s| s.as_ref())
-                        .filter(|s| !s.is_empty())
-                } else {
-                    None
-                };
-
-                let right = if show_col {
-                    RightCol {
-                        text: right_col,
-                        width: right_w,
-                    }
-                } else {
-                    RightCol::none()
-                };
+                let right = right_col_for(show_col, right_w, sort_column.as_ref(), idx);
 
                 items.push(make_entry_row(
                     entry,
@@ -364,32 +327,14 @@ pub(crate) fn draw_parent(
     }
 
     let sort_column = app.parent().sort_column();
-    let right_w = right_col_width(sort_column.as_ref());
-    let inner_w = context.block.inner(context.area).width;
-    let show_col = pane_show_col(inner_w, right_w);
+    let inner_w = pane_inner_width(&context);
+    let (show_col, right_w) = right_col_config(inner_w, sort_column.as_ref());
 
     let mut items = Vec::with_capacity(entries.len());
     for (idx, entry) in entries.iter().enumerate() {
         let is_selected = Some(idx) == selected_idx;
         let style = context.styles.get_style(entry.is_dir(), is_selected);
-        let right_col = if show_col {
-            sort_column
-                .as_ref()
-                .and_then(|c| c.get(idx))
-                .map(|s| s.as_ref())
-                .filter(|s| !s.is_empty())
-        } else {
-            None
-        };
-
-        let right = if show_col {
-            RightCol {
-                text: right_col,
-                width: right_w,
-            }
-        } else {
-            RightCol::none()
-        };
+        let right = right_col_for(show_col, right_w, sort_column.as_ref(), idx);
 
         items.push(make_entry_row(
             entry,
@@ -689,21 +634,6 @@ fn make_entry_row<'a>(
 }
 
 #[inline]
-fn right_col_width(sort_column: Option<&Vec<std::sync::Arc<str>>>) -> u16 {
-    let Some(col) = sort_column else {
-        return 0;
-    };
-    let mut max_w: usize = 0;
-    for s in col.iter() {
-        let w = UnicodeWidthStr::width(s.as_ref());
-        if w > max_w {
-            max_w = w;
-        }
-    }
-    (max_w as u16).min(MAX_RIGHT_COLUMN_WIDTH)
-}
-
-#[inline]
 fn pane_show_col(inner_w: u16, right_w: u16) -> bool {
     right_w > 0 && inner_w >= right_w + 1 + MIN_LEFT_WIDTH
 }
@@ -752,29 +682,48 @@ fn build_right_field(col: &str, total_w: usize, used_w: usize, col_area_w: usize
     out
 }
 
+#[inline]
 fn pane_inner_width(context: &PaneContext) -> u16 {
     context.block.inner(context.area).width
 }
 
-fn right_col_config<'a>(inner_w: u16, sort_column: Option<&Vec<Arc<str>>>) -> (bool, u16) {
+#[inline]
+fn right_col_width(sort_column: Option<&Vec<Arc<str>>>) -> u16 {
+    let Some(col) = sort_column else {
+        return 0;
+    };
+    let mut max_w: usize = 0;
+    for s in col.iter() {
+        let w = UnicodeWidthStr::width(s.as_ref());
+        if w > max_w {
+            max_w = w;
+        }
+    }
+    (max_w as u16).min(MAX_RIGHT_COLUMN_WIDTH)
+}
+
+#[inline]
+fn right_col_config(inner_w: u16, sort_column: Option<&Vec<Arc<str>>>) -> (bool, u16) {
     let right_w = right_col_width(sort_column);
     let show_col = pane_show_col(inner_w, right_w);
     (show_col, right_w)
 }
 
-fn right_col_at<'a>(sort_column: Option<&'a Vec<Arc<str>>>, idx: usize) -> Option<&'a str> {
+#[inline]
+fn right_col_at(sort_column: Option<&Vec<Arc<str>>>, idx: usize) -> Option<&str> {
     sort_column
         .and_then(|c| c.get(idx))
         .map(|s| s.as_ref())
         .filter(|s| !s.is_empty())
 }
 
-fn right_col_for<'a>(
+#[inline]
+fn right_col_for(
     show_col: bool,
     right_w: u16,
-    sort_column: Option<&'a Vec<Arc<str>>>,
+    sort_column: Option<&Vec<Arc<str>>>,
     idx: usize,
-) -> RightCol<'a> {
+) -> RightCol<'_> {
     if !show_col {
         return RightCol::none();
     }

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -580,7 +580,7 @@ fn make_entry_row<'a>(
         spans.push(Span::styled(name, row_style));
     }
 
-    if entry.is_dir() && context.show_marker {
+    if entry.is_dir() && context.show_marker && left_remaining(total_w, used_w, reserve) >= 1 {
         used_w += 1;
         let slash_style = if entry.is_symlink() {
             row_style.fg(symlink_fg)
@@ -591,35 +591,50 @@ fn make_entry_row<'a>(
     }
 
     if entry.is_symlink() {
-        if let Some(target) = entry.symlink() {
-            let target_str = target.to_string_lossy();
-            let mut sym_text = String::with_capacity(target_str.len() + 20);
-            sym_text.push_str(" -> ");
-            sym_text.push_str(&target_str);
+        let rem = left_remaining(total_w, used_w, reserve);
+        if rem > 0 {
+            if let Some(target) = entry.symlink() {
+                let target_str = target.to_string_lossy();
+                let mut sym_text = String::with_capacity(target_str.len() + 24);
+                sym_text.push_str(" -> ");
+                sym_text.push_str(&target_str);
 
-            let target_style = if entry.is_broken_sym() {
-                sym_text.push_str(" [broken]");
-                row_style.fg(symlink_fg)
-            } else {
-                row_style.fg(context.styles.symlink_target)
-            };
+                if entry.is_broken_sym() {
+                    sym_text.push_str(" [broken]");
+                }
 
-            used_w += UnicodeWidthStr::width(sym_text.as_str());
-            spans.push(Span::styled(sym_text, target_style));
-        } else if entry.is_broken_sym() {
-            let s = " -> [broken]";
-            used_w += UnicodeWidthStr::width(s);
-            spans.push(Span::styled(s, row_style.fg(Color::Red)));
+                let sym_text = truncate_owned(sym_text.as_str(), rem);
+                used_w += UnicodeWidthStr::width(sym_text.as_str());
+
+                let target_style = if entry.is_broken_sym() {
+                    row_style.fg(symlink_fg)
+                } else {
+                    row_style.fg(context.styles.symlink_target)
+                };
+
+                spans.push(Span::styled(sym_text, target_style));
+            } else if entry.is_broken_sym() {
+                let s = truncate_owned(" -> [broken]", rem);
+                used_w += UnicodeWidthStr::width(s.as_str());
+                spans.push(Span::styled(s, row_style.fg(Color::Red)));
+            }
         }
     }
 
     if let Some(col) = right_col {
         let total_w = context.area.width.saturating_sub(2) as usize;
-        let col_w = UnicodeWidthStr::width(col);
-        let pad_spaces = total_w.saturating_sub(used_w + col_w + 1);
+        let col_area_w = right_width as usize;
 
+        let pad_spaces = total_w.saturating_sub(used_w + 1 + col_area_w);
         spans.push(Span::raw(" ".repeat(pad_spaces)));
         spans.push(Span::raw(" "));
+
+        let col_w = UnicodeWidthStr::width(col).min(col_area_w);
+        let inner_pad = col_area_w.saturating_sub(col_w);
+        if inner_pad > 0 {
+            spans.push(Span::raw(" ".repeat(inner_pad)));
+        }
+
         spans.push(Span::styled(col, row_style.add_modifier(Modifier::DIM)));
     }
 
@@ -668,4 +683,9 @@ fn truncate_owned(s: &str, max_w: usize) -> String {
     }
     out.push('…');
     out
+}
+
+#[inline]
+fn left_remaining(total_w: usize, used_w: usize, reserve: usize) -> usize {
+    total_w.saturating_sub(reserve).saturating_sub(used_w)
 }

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -16,6 +16,8 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, List, ListItem, ListState, Paragraph},
 };
+use unicode_width::UnicodeWidthStr;
+
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -126,9 +128,17 @@ pub(crate) fn draw_main(
 
     let shown_len = app.nav().shown_entries_len();
     let mut items = Vec::with_capacity(shown_len);
-    for (idx, entry) in app.nav().shown_entries().enumerate() {
-        let is_selected = Some(idx) == selected_idx;
+    for (vis_idx, &abs_idx) in app.nav().shown_indices().iter().enumerate() {
+        let entry = &app.nav().entries()[abs_idx];
+        let is_selected = Some(vis_idx) == selected_idx;
         let entry_style = context.styles.get_style(entry.is_dir(), is_selected);
+        let right_col = app
+            .nav()
+            .sort_column()
+            .as_ref()
+            .and_then(|c| c.get(abs_idx))
+            .map(|s| s.as_ref());
+
         items.push(make_entry_row(
             entry,
             is_selected,
@@ -136,6 +146,7 @@ pub(crate) fn draw_main(
             &context,
             &markers,
             None,
+            right_col,
         ));
     }
 
@@ -165,12 +176,19 @@ pub(crate) fn draw_main(
 /// Also applies underline/selection styles and manages cursor position
 pub(crate) fn draw_preview(
     frame: &mut Frame,
+    app: &AppState,
     context: PaneContext,
-    preview: &PreviewData,
-    selected_idx: Option<usize>,
-    opts: PreviewOptions,
     markers: &PaneMarkers,
 ) {
+    let preview = app.preview().data();
+    let selected_idx = Some(app.preview().selected_idx());
+
+    let opts = PreviewOptions {
+        use_underline: app.config().display().preview_underline(),
+        underline_match_text: app.config().display().preview_underline_color(),
+        underline_style: app.config().theme().underline_style(),
+    };
+
     match preview {
         PreviewData::Empty => {
             frame.render_widget(
@@ -196,7 +214,10 @@ pub(crate) fn draw_preview(
             );
         }
 
-        PreviewData::Directory(entries) => {
+        PreviewData::Directory {
+            entries,
+            sort_column,
+        } => {
             if entries.is_empty() {
                 let style = context.styles.item;
                 let line = Line::from(vec![Span::raw(context.padding_str), Span::raw("[Empty]")]);
@@ -218,6 +239,12 @@ pub(crate) fn draw_preview(
             for (idx, entry) in entries.iter().enumerate() {
                 let is_selected = Some(idx) == selected_idx;
                 let style = context.styles.get_style(entry.is_dir(), is_selected);
+
+                let right_col = sort_column
+                    .as_ref()
+                    .and_then(|c| c.get(idx))
+                    .map(|s| s.as_ref());
+
                 items.push(make_entry_row(
                     entry,
                     is_selected,
@@ -225,6 +252,7 @@ pub(crate) fn draw_preview(
                     &context,
                     markers,
                     Some(&opts),
+                    right_col,
                 ));
             }
 
@@ -251,11 +279,13 @@ pub(crate) fn draw_preview(
 /// Draws the parent directory of the current working directory.
 pub(crate) fn draw_parent(
     frame: &mut Frame,
+    app: &AppState,
     context: PaneContext,
-    entries: &[FileEntry],
-    selected_idx: Option<usize>,
     markers: &PaneMarkers,
 ) {
+    let entries = app.parent().entries();
+    let selected_idx = app.parent().selected_idx();
+    let sort_column = app.parent().sort_column();
     if entries.is_empty() {
         frame.render_widget(
             Paragraph::new("").block(
@@ -273,6 +303,10 @@ pub(crate) fn draw_parent(
     for (idx, entry) in entries.iter().enumerate() {
         let is_selected = Some(idx) == selected_idx;
         let style = context.styles.get_style(entry.is_dir(), is_selected);
+        let right_col = sort_column
+            .as_ref()
+            .and_then(|c| c.get(idx))
+            .map(|s| s.as_ref());
         items.push(make_entry_row(
             entry,
             is_selected,
@@ -280,6 +314,7 @@ pub(crate) fn draw_parent(
             &context,
             markers,
             None,
+            right_col,
         ));
     }
 
@@ -399,7 +434,10 @@ fn make_entry_row<'a>(
     context: &PaneContext,
     markers: &PaneMarkers,
     opts: Option<&PreviewOptions>,
+    right_col: Option<&'a str>,
 ) -> ListItem<'a> {
+    let mut used_w: usize = 0;
+
     let is_marked = markers
         .markers
         .as_ref()
@@ -440,7 +478,9 @@ fn make_entry_row<'a>(
         }
     }
 
-    let pad = if (is_marked || is_copied) && !context.padding_str.is_empty() {
+    let mut spans = Vec::with_capacity(10);
+
+    if (is_marked || is_copied) && !context.padding_str.is_empty() {
         let first_char_len = context
             .padding_str
             .chars()
@@ -451,13 +491,12 @@ fn make_entry_row<'a>(
         s.push_str(markers.marker_icon);
         s.push_str(&context.padding_str[first_char_len..]);
 
-        Span::styled(s, icon_style)
+        used_w += UnicodeWidthStr::width(s.as_str());
+        spans.push(Span::styled(s, icon_style));
     } else {
-        Span::raw(context.padding_str)
-    };
-
-    let mut spans = Vec::with_capacity(8);
-    spans.push(pad);
+        used_w += UnicodeWidthStr::width(context.padding_str);
+        spans.push(Span::raw(context.padding_str));
+    }
 
     let symlink_fg = if entry.is_broken_sym() {
         Color::Red
@@ -477,6 +516,8 @@ fn make_entry_row<'a>(
         icon_col.push_str(icon);
         icon_col.push(' ');
 
+        used_w += UnicodeWidthStr::width(icon_col.as_str());
+
         let icon_render_style = if entry.is_symlink() {
             row_style.fg(symlink_fg).add_modifier(Modifier::BOLD)
         } else {
@@ -486,13 +527,17 @@ fn make_entry_row<'a>(
         spans.push(Span::styled(icon_col, icon_render_style));
     }
 
+    let name = entry.name_str();
+    used_w += UnicodeWidthStr::width(name.as_ref());
+
     if entry.is_symlink() {
-        spans.push(Span::styled(entry.name_str(), row_style.fg(symlink_fg)));
+        spans.push(Span::styled(name, row_style.fg(symlink_fg)));
     } else {
-        spans.push(Span::styled(entry.name_str(), row_style));
+        spans.push(Span::styled(name, row_style));
     }
 
     if entry.is_dir() && context.show_marker {
+        used_w += 1;
         let slash_style = if entry.is_symlink() {
             row_style.fg(symlink_fg)
         } else {
@@ -515,9 +560,23 @@ fn make_entry_row<'a>(
                 row_style.fg(context.styles.symlink_target)
             };
 
+            used_w += UnicodeWidthStr::width(sym_text.as_str());
             spans.push(Span::styled(sym_text, target_style));
         } else if entry.is_broken_sym() {
-            spans.push(Span::styled(" -> [broken]", row_style.fg(Color::Red)));
+            let s = " -> [broken]";
+            used_w += UnicodeWidthStr::width(s);
+            spans.push(Span::styled(s, row_style.fg(Color::Red)));
+        }
+    }
+
+    if let Some(col) = right_col {
+        let total_w = context.area.width as usize;
+        let col_w = UnicodeWidthStr::width(col);
+
+        if total_w > used_w + col_w + 1 {
+            let pad_spaces = total_w - used_w - col_w;
+            spans.push(Span::raw(" ".repeat(pad_spaces)));
+            spans.push(Span::styled(col, row_style.add_modifier(Modifier::DIM)));
         }
     }
 

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -16,11 +16,14 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, List, ListItem, ListState, Paragraph},
 };
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+
+const MAX_RIGHT_COLUMN_WIDTH: u16 = 24;
+const MIN_LEFT_WIDTH: u16 = 12;
 
 /// Styles used for rendering items in a pane
 /// Includes styles for regular items, directories and selected items
@@ -127,17 +130,25 @@ pub(crate) fn draw_main(
     let markers = make_main_pane_markers(app, current_dir, clipboard);
 
     let shown_len = app.nav().shown_entries_len();
+
+    let sort_column = app.nav().sort_column();
+    let right_w = right_col_width(sort_column.as_ref());
+    let inner_w = context.area.width.saturating_sub(2);
+    let show_col = pane_show_col(inner_w, right_w);
+
     let mut items = Vec::with_capacity(shown_len);
     for (vis_idx, &abs_idx) in app.nav().shown_indices().iter().enumerate() {
         let entry = &app.nav().entries()[abs_idx];
         let is_selected = Some(vis_idx) == selected_idx;
         let entry_style = context.styles.get_style(entry.is_dir(), is_selected);
-        let right_col = app
-            .nav()
-            .sort_column()
-            .as_ref()
-            .and_then(|c| c.get(abs_idx))
-            .map(|s| s.as_ref());
+        let right_col = if show_col {
+            sort_column
+                .as_ref()
+                .and_then(|c| c.get(abs_idx))
+                .map(|s| s.as_ref())
+        } else {
+            None
+        };
 
         items.push(make_entry_row(
             entry,
@@ -147,6 +158,7 @@ pub(crate) fn draw_main(
             &markers,
             None,
             right_col,
+            right_w,
         ));
     }
 
@@ -235,15 +247,23 @@ pub(crate) fn draw_preview(
                 return;
             }
 
+            let right_w = right_col_width(sort_column.as_ref());
+            let inner_w = context.area.width.saturating_sub(2);
+            let show_col = pane_show_col(inner_w, right_w);
+
             let mut items = Vec::with_capacity(entries.len());
             for (idx, entry) in entries.iter().enumerate() {
                 let is_selected = Some(idx) == selected_idx;
                 let style = context.styles.get_style(entry.is_dir(), is_selected);
 
-                let right_col = sort_column
-                    .as_ref()
-                    .and_then(|c| c.get(idx))
-                    .map(|s| s.as_ref());
+                let right_col = if show_col {
+                    sort_column
+                        .as_ref()
+                        .and_then(|c| c.get(idx))
+                        .map(|s| s.as_ref())
+                } else {
+                    None
+                };
 
                 items.push(make_entry_row(
                     entry,
@@ -253,6 +273,7 @@ pub(crate) fn draw_preview(
                     markers,
                     Some(&opts),
                     right_col,
+                    right_w,
                 ));
             }
 
@@ -285,7 +306,6 @@ pub(crate) fn draw_parent(
 ) {
     let entries = app.parent().entries();
     let selected_idx = app.parent().selected_idx();
-    let sort_column = app.parent().sort_column();
     if entries.is_empty() {
         frame.render_widget(
             Paragraph::new("").block(
@@ -299,14 +319,23 @@ pub(crate) fn draw_parent(
         return;
     }
 
+    let sort_column = app.parent().sort_column();
+    let right_w = right_col_width(sort_column.as_ref());
+    let inner_w = context.area.width.saturating_sub(2);
+    let show_col = pane_show_col(inner_w, right_w);
+
     let mut items = Vec::with_capacity(entries.len());
     for (idx, entry) in entries.iter().enumerate() {
         let is_selected = Some(idx) == selected_idx;
         let style = context.styles.get_style(entry.is_dir(), is_selected);
-        let right_col = sort_column
-            .as_ref()
-            .and_then(|c| c.get(idx))
-            .map(|s| s.as_ref());
+        let right_col = if show_col {
+            sort_column
+                .as_ref()
+                .and_then(|c| c.get(idx))
+                .map(|s| s.as_ref())
+        } else {
+            None
+        };
         items.push(make_entry_row(
             entry,
             is_selected,
@@ -315,6 +344,7 @@ pub(crate) fn draw_parent(
             markers,
             None,
             right_col,
+            right_w,
         ));
     }
 
@@ -435,6 +465,7 @@ fn make_entry_row<'a>(
     markers: &PaneMarkers,
     opts: Option<&PreviewOptions>,
     right_col: Option<&'a str>,
+    right_width: u16,
 ) -> ListItem<'a> {
     let mut used_w: usize = 0;
 
@@ -527,8 +558,21 @@ fn make_entry_row<'a>(
         spans.push(Span::styled(icon_col, icon_render_style));
     }
 
-    let name = entry.name_str();
-    used_w += UnicodeWidthStr::width(name.as_ref());
+    let total_w = context.area.width.saturating_sub(2) as usize;
+    let reserve = if right_col.is_some() {
+        (right_width as usize) + 1
+    } else {
+        0
+    };
+
+    let name_raw = entry.name_str();
+    let name_budget = total_w
+        .saturating_sub(reserve)
+        .saturating_sub(used_w)
+        .max(1);
+    let name = truncate_owned(name_raw.as_ref(), name_budget);
+
+    used_w += UnicodeWidthStr::width(name.as_str());
 
     if entry.is_symlink() {
         spans.push(Span::styled(name, row_style.fg(symlink_fg)));
@@ -570,15 +614,58 @@ fn make_entry_row<'a>(
     }
 
     if let Some(col) = right_col {
-        let total_w = context.area.width as usize;
+        let total_w = context.area.width.saturating_sub(2) as usize;
         let col_w = UnicodeWidthStr::width(col);
+        let pad_spaces = total_w.saturating_sub(used_w + col_w + 1);
 
-        if total_w > used_w + col_w + 1 {
-            let pad_spaces = total_w - used_w - col_w;
-            spans.push(Span::raw(" ".repeat(pad_spaces)));
-            spans.push(Span::styled(col, row_style.add_modifier(Modifier::DIM)));
-        }
+        spans.push(Span::raw(" ".repeat(pad_spaces)));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(col, row_style.add_modifier(Modifier::DIM)));
     }
 
     ListItem::new(Line::from(spans)).style(row_style)
+}
+
+#[inline]
+fn right_col_width(sort_column: Option<&Vec<std::sync::Arc<str>>>) -> u16 {
+    let Some(col) = sort_column else {
+        return 0;
+    };
+    let mut max_w: usize = 0;
+    for s in col.iter() {
+        let w = UnicodeWidthStr::width(s.as_ref());
+        if w > max_w {
+            max_w = w;
+        }
+    }
+    (max_w as u16).min(MAX_RIGHT_COLUMN_WIDTH)
+}
+
+#[inline]
+fn pane_show_col(inner_w: u16, right_w: u16) -> bool {
+    right_w > 0 && inner_w >= right_w + 1 + MIN_LEFT_WIDTH
+}
+
+fn truncate_owned(s: &str, max_w: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max_w {
+        return s.to_string();
+    }
+    if max_w <= 1 {
+        return "…".to_string();
+    }
+    let mut out = String::with_capacity(max_w);
+    let mut w = 0usize;
+    for ch in s.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if w + cw >= max_w {
+            break;
+        }
+        out.push(ch);
+        w += cw;
+    }
+    if !out.is_empty() {
+        out.pop();
+    }
+    out.push('…');
+    out
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -8,13 +8,13 @@
 
 use crate::{
     app::{
-        AppState, Clipboard, LayoutMetrics, PreviewData,
+        AppState, Clipboard, LayoutMetrics,
         actions::{ActionMode, InputMode},
     },
     core::worker::Workers,
     ui::{
         overlays::Overlay,
-        panes::{self, PaneContext, PaneStyles, PreviewOptions},
+        panes::{self, PaneContext, PaneStyles},
         widgets,
     },
 };
@@ -95,6 +95,7 @@ pub(crate) fn render(
 
         panes::draw_parent(
             frame,
+            app,
             PaneContext {
                 area: chunks[pane_idx],
                 block: widgets::get_pane_block("Parent", app),
@@ -106,8 +107,6 @@ pub(crate) fn render(
                 show_icons: display_cfg.icons(),
                 show_marker: display_cfg.dir_marker(),
             },
-            app.parent().entries(),
-            app.parent().selected_idx(),
             &parent_markers,
         );
         pane_idx += 1;
@@ -194,16 +193,9 @@ pub(crate) fn render(
             executable_fg: theme_cfg.exe_color(),
         };
 
-        let (preview_data, selected_idx) = {
-            let preview = app.preview();
-            match preview.data() {
-                PreviewData::Directory(_) => (preview.data(), Some(preview.selected_idx())),
-                _ => (preview.data(), None),
-            }
-        };
-
         panes::draw_preview(
             frame,
+            app,
             PaneContext {
                 area: chunks[pane_idx],
                 block: widgets::get_pane_block("Preview", app),
@@ -214,13 +206,6 @@ pub(crate) fn render(
                 padding_str,
                 show_icons: display_cfg.icons(),
                 show_marker: display_cfg.dir_marker(),
-            },
-            preview_data,
-            selected_idx,
-            PreviewOptions {
-                use_underline: display_cfg.preview_underline(),
-                underline_match_text: display_cfg.preview_underline_color(),
-                underline_style: theme_cfg.underline_style(),
             },
             &preview_markers,
         );

--- a/src/ui/widgets/draw.rs
+++ b/src/ui/widgets/draw.rs
@@ -777,45 +777,55 @@ pub(crate) fn draw_prefix_help_overlay(frame: &mut Frame, app: &AppState, accent
 
     let is_sort_prefix = app.actions().prefix_recognizer().is_sort_state();
     if is_sort_prefix {
-        let mut spans = Vec::with_capacity(7 * 4);
+        fn mk_line(items: &[(&str, &str)], accent_style: Style) -> Line<'static> {
+            let mut spans: Vec<Span<'static>> = Vec::with_capacity(items.len() * 4);
+            for (i, (key, desc)) in items.iter().enumerate() {
+                if i > 0 {
+                    spans.push(Span::raw("    "));
+                }
+                spans.push(Span::styled(format!("[{}]", key), accent_style));
+                spans.push(Span::raw(" "));
+                spans.push(Span::raw((*desc).to_string()));
+            }
+            Line::from(spans)
+        }
 
-        let items: [(&str, &str); 7] = [
+        let row1: [(&str, &str); 4] = [
             ("n", "Name"),
             ("m", "Modified"),
             ("c", "Created"),
             ("a", "Accessed"),
-            ("s", "Size"),
-            ("e", "Ext"),
-            ("z", "Natural"),
         ];
+        let row2: [(&str, &str); 3] = [("s", "Size"), ("e", "Ext"), ("z", "Natural")];
 
-        for (index, (key, desc)) in items.iter().enumerate() {
-            if index > 0 {
-                spans.push(Span::raw("    "));
-            }
-            spans.push(Span::styled(format!("[{}]", key), accent_style));
-            spans.push(Span::raw(" "));
-            spans.push(Span::raw(*desc));
-        }
+        let lines: Vec<Line<'static>> =
+            vec![mk_line(&row1, accent_style), mk_line(&row2, accent_style)];
 
-        spans.push(Span::raw("    "));
-        spans.push(Span::raw("(press same key again to reverse)"));
+        let area = frame.area();
+        let border_pad = 2usize;
+        let inner_pad = 2usize;
 
-        let line = Line::from(spans);
+        let max_line_w = lines.iter().map(|l| l.width()).max().unwrap_or(0);
 
-        let size = widget.go_to_help_size();
-        let position = widget.go_to_help_position();
+        let min_width = 24usize;
+        let max_width = (area.width as usize).saturating_sub(2).max(min_width);
+
+        let width = (max_line_w + inner_pad + border_pad)
+            .max(min_width)
+            .min(max_width) as u16;
+
+        let height = (lines.len() + border_pad).min(area.height as usize) as u16;
 
         draw_dialog(
             frame,
             DialogLayout {
                 area,
-                position,
-                size,
+                position: widget.go_to_help_position(),
+                size: DialogSize::Custom(width, height),
             },
             border_type,
             &get_dialog_style(app, accent_style, "Sort", None),
-            line,
+            Text::from(lines),
             Some(Alignment::Center),
             None,
         );

--- a/src/ui/widgets/draw.rs
+++ b/src/ui/widgets/draw.rs
@@ -767,10 +767,60 @@ pub(crate) fn draw_find_dialog(frame: &mut Frame, app: &AppState, accent_style: 
 }
 
 pub(crate) fn draw_prefix_help_overlay(frame: &mut Frame, app: &AppState, accent_style: Style) {
+    let widget = app.config().theme().widget();
+    let area = frame.area();
+    let border_type = app.config().display().border_shape().as_border_type();
     let keys = app.config().keys();
     let go_to_top_keys = keys.go_to_top();
     let go_to_home_keys = keys.go_to_home();
     let go_to_path_keys = keys.go_to_path();
+
+    let is_sort_prefix = app.actions().prefix_recognizer().is_sort_state();
+    if is_sort_prefix {
+        let mut spans = Vec::with_capacity(7 * 4);
+
+        let items: [(&str, &str); 7] = [
+            ("n", "Name"),
+            ("m", "Modified"),
+            ("c", "Created"),
+            ("a", "Accessed"),
+            ("s", "Size"),
+            ("e", "Ext"),
+            ("z", "Natural"),
+        ];
+
+        for (index, (key, desc)) in items.iter().enumerate() {
+            if index > 0 {
+                spans.push(Span::raw("    "));
+            }
+            spans.push(Span::styled(format!("[{}]", key), accent_style));
+            spans.push(Span::raw(" "));
+            spans.push(Span::raw(*desc));
+        }
+
+        spans.push(Span::raw("    "));
+        spans.push(Span::raw("(press same key again to reverse)"));
+
+        let line = Line::from(spans);
+
+        let size = widget.go_to_help_size();
+        let position = widget.go_to_help_position();
+
+        draw_dialog(
+            frame,
+            DialogLayout {
+                area,
+                position,
+                size,
+            },
+            border_type,
+            &get_dialog_style(app, accent_style, "Sort", None),
+            line,
+            Some(Alignment::Center),
+            None,
+        );
+        return;
+    }
 
     let mut g_prefixes: Vec<(String, &'static str)> =
         Vec::with_capacity(go_to_top_keys.len() + go_to_path_keys.len());
@@ -797,13 +847,8 @@ pub(crate) fn draw_prefix_help_overlay(frame: &mut Frame, app: &AppState, accent
     spans.push(Span::raw(" "));
     let line = Line::from(spans);
 
-    let widget = app.config().theme().widget();
-    let area = frame.area();
-
     let size = widget.go_to_help_size();
     let position = widget.go_to_help_position();
-
-    let border_type = app.config().display().border_shape().as_border_type();
 
     draw_dialog(
         frame,

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -12,6 +12,7 @@
 //! These helpers are used throughout runa.
 
 use crate::config::Editor;
+use crate::core::metadata::bump_meta_sort_epoch;
 use ratatui::style::Color;
 use std::borrow::Cow;
 use std::ffi::OsStr;
@@ -115,6 +116,7 @@ pub(crate) fn open_in_editor(editor: &Editor, file_path: &Path) -> std::io::Resu
     let mut stdout = io::stdout();
     disable_raw_mode()?;
     execute!(stdout, LeaveAlternateScreen)?;
+    bump_meta_sort_epoch();
 
     let status = std::process::Command::new(editor_path)
         .arg(file_path)


### PR DESCRIPTION
## Alpha 0.10.0 release for Sorting/UI refactor

### Added sorting by natural, name, size, created, modified, accessed

- Prefix sort keybind to open the prefix state to then sort by each option
- Added a new worker thread for sorting per directory, making the sorting blazing fast.
- Put all the planned 0.9.2 performance improvements and changes into 0.10.0-alpha.1

Note!: This build still needs a good amount of testing and polish. Its in a good enough state to push it to main, but it will see many changes to how it will work.