### PR TITLE
Feature/config reload

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,19 +20,21 @@ pub(crate) use preview::{PreviewData, PreviewState};
 pub(crate) use state::{AppState, KeypressResult, LayoutMetrics};
 pub(crate) use tab::{handle_sort_action, handle_tab_action};
 
+use crate::config::Config;
 use crate::{app::tab::TabManager, core::workers::Workers};
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 /// The main container enum to hold either the TabManager or a single boxed AppState to then match
 /// either a single state or a tabs which then hold multiple AppStates.
-pub(crate) enum AppContainer<'a> {
-    Single(Box<AppState<'a>>),
-    Tabs(Box<TabManager<'a>>),
+pub(crate) enum AppContainer {
+    Single(Box<AppState>),
+    Tabs(Box<TabManager>),
 }
 
-impl<'a> AppContainer<'a> {
-    pub(crate) fn create_tabs(tabs: Vec<AppState<'a>>) -> Self {
+impl AppContainer {
+    pub(crate) fn create_tabs(tabs: Vec<AppState>) -> Self {
         Self::Tabs(Box::new(tab::TabManager::from_vec(tabs)))
     }
 }
@@ -53,13 +55,29 @@ impl Clipboard {
 
 /// The main struct of runa
 /// Contains the AppContainer, the shared clipboard and the worker pool
-pub(crate) struct RunaRoot<'a> {
-    pub(crate) container: AppContainer<'a>,
+pub(crate) struct RunaRoot {
+    pub(crate) container: AppContainer,
     pub(crate) clipboard: Clipboard,
     pub(crate) workers: Workers,
 }
 
-impl RunaRoot<'_> {
+impl RunaRoot {
+    pub(crate) fn reload_config(&mut self) {
+        let new_config = Arc::new(Config::load());
+
+        match &mut self.container {
+            AppContainer::Single(app) => {
+                app.apply_new_config(Arc::clone(&new_config), &self.workers);
+            }
+            AppContainer::Tabs(tabs) => {
+                for tab in &mut tabs.tabs {
+                    tab.apply_new_config(Arc::clone(&new_config), &self.workers);
+                }
+                tabs.sync_tab_line();
+            }
+        }
+    }
+
     pub(crate) fn update(&mut self) -> bool {
         let mut changed = false;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,7 @@ use crate::{app::tab::TabManager, core::workers::Workers};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// The main container enum to hold either the TabManager or a single boxed AppState to then match
 /// either a single state or a tabs which then hold multiple AppStates.
@@ -63,17 +64,36 @@ pub(crate) struct RunaRoot {
 
 impl RunaRoot {
     pub(crate) fn reload_config(&mut self) {
-        let new_config = Arc::new(Config::load());
+        match Config::load() {
+            Ok(config) => {
+                let new_config = Arc::new(config);
 
-        match &mut self.container {
-            AppContainer::Single(app) => {
-                app.apply_new_config(Arc::clone(&new_config), &self.workers);
-            }
-            AppContainer::Tabs(tabs) => {
-                for tab in &mut tabs.tabs {
-                    tab.apply_new_config(Arc::clone(&new_config), &self.workers);
+                match &mut self.container {
+                    AppContainer::Single(app) => {
+                        app.apply_new_config(Arc::clone(&new_config), &self.workers);
+                        app.push_overlay_message(
+                            " Config reloaded!".into(),
+                            Duration::from_secs(2),
+                        );
+                    }
+                    AppContainer::Tabs(tabs) => {
+                        for tab in &mut tabs.tabs {
+                            tab.apply_new_config(Arc::clone(&new_config), &self.workers);
+                        }
+                        tabs.sync_tab_line();
+                        tabs.tabs[tabs.current].push_overlay_message(
+                            " Config reloaded!".into(),
+                            Duration::from_secs(2),
+                        );
+                    }
                 }
-                tabs.sync_tab_line();
+            }
+            Err(e) => {
+                let target_app = match &mut self.container {
+                    AppContainer::Single(app) => app,
+                    AppContainer::Tabs(tabs) => &mut tabs.tabs[tabs.current],
+                };
+                target_app.push_overlay_message(e, Duration::from_secs(5));
             }
         }
     }

--- a/src/app/handlers/file_actions.rs
+++ b/src/app/handlers/file_actions.rs
@@ -30,7 +30,7 @@ use crate::app::{
 use crate::config::Editor;
 
 /// AppState file action handlers
-impl<'a> AppState<'a> {
+impl AppState {
     /// Handles file actions (open, delete, copy, etc).
     /// Returns a [KeypressResult] indicating how the action was handled.
     pub(in crate::app) fn handle_file_action(

--- a/src/app/handlers/input_mode.rs
+++ b/src/app/handlers/input_mode.rs
@@ -27,7 +27,7 @@ use crate::ui::overlays::OverlayKind;
 use crate::utils::{os, path};
 
 /// AppState input handlers
-impl<'a> AppState<'a> {
+impl AppState {
     // AppState core handlers
 
     /// Handles key events when in an input mode (rename, filter, etc).
@@ -186,6 +186,7 @@ impl<'a> AppState<'a> {
                 self.toggle_keybind_help();
                 KeypressResult::Consumed
             }
+            SystemAction::Reload => KeypressResult::ReloadConfig,
         }
     }
 

--- a/src/app/handlers/nav_actions.rs
+++ b/src/app/handlers/nav_actions.rs
@@ -21,7 +21,7 @@ use crate::app::{
 };
 use crate::utils::{os, path, timings::Timings};
 
-impl<'a> AppState<'a> {
+impl AppState {
     /// Handles navigation actions (up, down, into dir, etc).
     /// Returns a [KeypressResult] indicating how the action was handled.
     pub(in crate::app) fn handle_nav_action(

--- a/src/app/handlers/overlay_handlers.rs
+++ b/src/app/handlers/overlay_handlers.rs
@@ -13,7 +13,7 @@ use crate::core::metadata::FileMetadataCache;
 use crate::ui::overlays::{Overlay, OverlayKind};
 
 /// AppState input and action handlers
-impl<'a> AppState<'a> {
+impl AppState {
     pub(in crate::app) fn handle_esc_close_overlays(
         &mut self,
         key: &KeyEvent,

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -71,6 +71,7 @@ pub(crate) enum TabAction {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum SystemAction {
     Quit,
+    Reload,
     KeyBindHelp,
 }
 
@@ -176,6 +177,7 @@ impl Keymap {
         // SystemActions
         bind!(keys.keybind_help(),      Action::System(S::KeyBindHelp));
         bind!(keys.quit(),              Action::System(S::Quit));
+        bind!(keys.reload(),            Action::System(S::Reload));
 
         // Prefix actions
         bind_prefix!(keys.go_to_top(),  Action::Nav(N::GoToTop),  PrefixCommand::Nav(N::GoToTop));

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -39,6 +39,7 @@ pub(crate) enum KeypressResult {
     Quit,
     OpenedEditor,
     Recovered,
+    ReloadConfig,
     Tab(TabAction),
     Sort(SortConfig),
 }
@@ -69,8 +70,8 @@ impl Default for LayoutMetrics {
 ///
 /// Functions are provided for the core event loop, input handling, file navigationm
 /// worker requests and Notification management.
-pub(crate) struct AppState<'a> {
-    pub(super) config: &'a Config,
+pub(crate) struct AppState {
+    pub(super) config: Arc<Config>,
     pub(super) keymap: Keymap,
 
     pub(super) metrics: LayoutMetrics,
@@ -93,22 +94,22 @@ pub(crate) struct AppState<'a> {
     pub(super) overlays: OverlayStack,
 
     pub(super) tab_id: Option<usize>,
-    pub(super) tab_line: Arc<Vec<Span<'a>>>,
+    pub(super) tab_line: Arc<Vec<Span<'static>>>,
 }
 
-impl<'a> AppState<'a> {
-    pub(crate) fn new(config: &'a Config) -> std::io::Result<Self> {
+impl AppState {
+    pub(crate) fn new(config: Arc<Config>) -> std::io::Result<Self> {
         let current_dir = std::env::current_dir()?;
         Self::from_dir(config, &current_dir)
     }
 
     pub(crate) fn new_current_dir(&self) -> std::io::Result<Self> {
-        let mut app = Self::from_dir(self.config, self.nav.current_dir())?;
+        let mut app = Self::from_dir(Arc::clone(&self.config), self.nav.current_dir())?;
         app.nav.set_sort_config(self.nav.sort_config());
         Ok(app)
     }
 
-    pub(crate) fn from_dir(config: &'a Config, initial_path: &Path) -> std::io::Result<Self> {
+    pub(crate) fn from_dir(config: Arc<Config>, initial_path: &Path) -> std::io::Result<Self> {
         let current_dir = if initial_path.exists() && initial_path.is_dir() {
             initial_path.to_path_buf()
         } else {
@@ -116,8 +117,8 @@ impl<'a> AppState<'a> {
         };
 
         let app = Self {
+            keymap: Keymap::from_config(config.as_ref()),
             config,
-            keymap: Keymap::from_config(config),
             metrics: LayoutMetrics::default(),
             nav: NavState::new(current_dir),
             actions: ActionContext::default(),
@@ -137,6 +138,23 @@ impl<'a> AppState<'a> {
         Ok(app)
     }
 
+    pub(crate) fn apply_new_config(&mut self, config: Arc<Config>, workers: &Workers) {
+        self.config = config;
+        self.keymap = Keymap::from_config(self.config.as_ref());
+
+        self.actions.prefix_recognizer_mut().cancel();
+        self.hide_prefix_help();
+
+        workers.cache().invalidate_path(self.nav.current_dir());
+
+        let focus = self.nav.selected_entry().map(|e| e.name().to_os_string());
+
+        self.request_dir_load(workers, focus);
+        self.request_parent_content(workers);
+
+        self.preview.mark_pending();
+    }
+
     /// Initializes the AppState by requesting the initial directory load and parent content.
     pub(crate) fn initialize(&mut self, workers: &Workers, focus: Option<OsString>) {
         self.request_dir_load(workers, focus);
@@ -144,7 +162,6 @@ impl<'a> AppState<'a> {
     }
 
     crate::getters! {
-        config: &Config,
         nav: &NavState,
         actions: &ActionContext,
         preview: &PreviewState,
@@ -152,6 +169,11 @@ impl<'a> AppState<'a> {
         is_loading: bool,
         worker_time: &Option<Instant>,
         overlays: &OverlayStack,
+    }
+
+    #[inline]
+    pub(crate) fn config(&self) -> &Config {
+        self.config.as_ref()
     }
 
     #[inline]
@@ -757,7 +779,7 @@ mod tests {
     fn appstate_new_from_dir_sets_initial_state() -> Result<(), Box<dyn std::error::Error>> {
         let config = dummy_config();
         let temp = tempdir()?;
-        let app = AppState::from_dir(&config, temp.path())?;
+        let app = AppState::from_dir(Arc::new(config), temp.path())?;
         assert_eq!(app.nav().current_dir(), temp.path());
         Ok(())
     }
@@ -767,7 +789,7 @@ mod tests {
         let config = dummy_config();
         let workers = dummy_workers();
         let temp = tempdir()?;
-        let mut app = AppState::from_dir(&config, temp.path())?;
+        let mut app = AppState::from_dir(Arc::new(config), temp.path())?;
         app.notification_time = Some(Instant::now() - Duration::from_secs(2));
         app.overlays_mut().push(Overlay::Message {
             text: "Timed MSG".to_string(),
@@ -783,7 +805,7 @@ mod tests {
     fn visible_selected_and_has_visible_entries() -> Result<(), Box<dyn std::error::Error>> {
         let config = dummy_config();
         let temp = tempdir()?;
-        let app = AppState::from_dir(&config, temp.path())?;
+        let app = AppState::from_dir(Arc::new(config), temp.path())?;
         let app_nav = app.nav();
         if app_nav.entries().is_empty() {
             assert_eq!(app.visible_selected(), None);
@@ -803,7 +825,7 @@ mod tests {
 
         let mut clipboard = Clipboard::default();
 
-        let mut app = AppState::from_dir(&config, temp.path())?;
+        let mut app = AppState::from_dir(Arc::new(config), temp.path())?;
         let key = KeyEvent::new(KeyCode::Null, KeyModifiers::NONE);
         let result = app.handle_keypress(key, &workers, &mut clipboard);
         assert!(matches!(result, KeypressResult::Continue));
@@ -815,7 +837,7 @@ mod tests {
         let config = dummy_config();
         let workers = dummy_workers();
         let temp = tempdir()?;
-        let mut app = AppState::from_dir(&config, temp.path())?;
+        let mut app = AppState::from_dir(Arc::new(config), temp.path())?;
         app.is_loading = false;
         app.request_dir_load(&workers, None);
         assert!(app.is_loading);
@@ -827,7 +849,7 @@ mod tests {
         let config = dummy_config();
         let workers = dummy_workers();
         let temp = tempdir()?;
-        let mut app = AppState::from_dir(&config, temp.path())?;
+        let mut app = AppState::from_dir(Arc::new(config), temp.path())?;
         #[cfg(unix)]
         {
             use std::path::PathBuf;
@@ -852,7 +874,7 @@ mod tests {
         let temp = tempdir()?;
         let subdir = temp.path().join("subdir");
         std::fs::create_dir(&subdir)?;
-        let mut app = AppState::from_dir(&config, &subdir)?;
+        let mut app = AppState::from_dir(Arc::new(config), &subdir)?;
 
         let parent_path = app
             .nav()

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -15,18 +15,18 @@ use crate::app::{AppContainer, AppState, KeypressResult, keymap::TabAction};
 use crate::core::{sort::SortConfig, workers::Workers};
 use crate::utils::path;
 
-pub(crate) struct TabManager<'a> {
-    pub(crate) tabs: Vec<AppState<'a>>,
+pub(crate) struct TabManager {
+    pub(crate) tabs: Vec<AppState>,
     pub(crate) current: usize,
     next_tab_id: usize,
 }
 
-impl<'a> TabManager<'a> {
+impl TabManager {
     const MAX_TABS: usize = 9;
 
     pub(crate) fn new(
-        mut existing: AppState<'a>,
-        mut new_tab: AppState<'a>,
+        mut existing: AppState,
+        mut new_tab: AppState,
         workers: &Workers,
         focus: Option<OsString>,
     ) -> Self {
@@ -44,7 +44,7 @@ impl<'a> TabManager<'a> {
         manager
     }
 
-    pub(crate) fn from_vec(mut tabs: Vec<AppState<'a>>) -> Self {
+    pub(crate) fn from_vec(mut tabs: Vec<AppState>) -> Self {
         for (i, tab) in tabs.iter_mut().enumerate() {
             tab.tab_id = Some(i);
         }
@@ -69,17 +69,17 @@ impl<'a> TabManager<'a> {
         self.tabs.is_empty()
     }
 
-    pub(crate) fn current_tab(&self) -> &AppState<'a> {
+    pub(crate) fn current_tab(&self) -> &AppState {
         &self.tabs[self.current]
     }
 
-    pub(crate) fn current_tab_mut(&mut self) -> &mut AppState<'a> {
+    pub(crate) fn current_tab_mut(&mut self) -> &mut AppState {
         &mut self.tabs[self.current]
     }
 
     pub(crate) fn add_tab(
         &mut self,
-        mut tab: AppState<'a>,
+        mut tab: AppState,
         workers: &Workers,
         focus: Option<OsString>,
     ) -> usize {
@@ -134,8 +134,10 @@ impl<'a> TabManager<'a> {
         let tab_spans = if self.tabs.len() <= 1 {
             Vec::new()
         } else {
-            let theme = self.tabs[self.current].config.theme();
-            let tab_theme = &theme.tab();
+            let (tab_theme, separator) = {
+                let theme = self.tabs[self.current].config().theme();
+                (theme.tab().clone(), theme.tab().separator().to_string())
+            };
 
             let mut spans = Vec::with_capacity(self.tabs.len() * 2 - 1);
             for (i, tab) in self.tabs.iter().enumerate() {
@@ -161,7 +163,7 @@ impl<'a> TabManager<'a> {
 
                 spans.push(Span::styled(formatted, style));
                 if i != self.tabs.len() - 1 {
-                    spans.push(Span::raw(tab_theme.separator()));
+                    spans.push(Span::raw(separator.clone()));
                 }
             }
             spans
@@ -173,9 +175,9 @@ impl<'a> TabManager<'a> {
     }
 }
 
-pub(crate) fn handle_tab_action<'a>(
+pub(crate) fn handle_tab_action(
     workers: &Workers,
-    container: &mut AppContainer<'a>,
+    container: &mut AppContainer,
     action: TabAction,
 ) -> KeypressResult {
     match action {

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -118,7 +118,6 @@ define_keys!(
     TabClose => tab_close = ["<c-w>"],
     TabNext => tab_next = ["<c-n>"],
     TabPrev => tab_prev = ["<c-p>"],
-    KeybindHelp => keybind_help = ["?"],
     ScrollUp => scroll_up = ["pgup"],
     ScrollDown => scroll_down = ["pgdn"],
     Sort => sort = ["o"],
@@ -129,6 +128,8 @@ define_keys!(
     SortByModified => sort_by_modified = ["m"],
     SortByAccessed => sort_by_accessed = ["a"],
     SortByCreated => sort_by_created = ["c"],
+    KeybindHelp => keybind_help = ["?"],
+    Reload => reload = ["<c-r>"],
 );
 
 /// Editor configuration options

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -75,22 +75,16 @@ impl Config {
     /// Also applies any necessary overrides to the theme after loading.
     ///
     /// Called by entry point to load config at startup.
-    pub(crate) fn load() -> Self {
+    pub(crate) fn load() -> Result<Self, String> {
         let path = Self::default_path();
-        let content = match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => return Self::default(),
-        };
+        let content =
+            fs::read_to_string(&path).map_err(|e| format!("Failed to read config file: {}", e))?;
 
-        toml::from_str::<RawConfig>(&content)
-            .map(|mut raw| {
-                raw.theme = raw.theme.with_overrides();
-                raw.into()
-            })
-            .unwrap_or_else(|e| {
-                eprintln!("Error parsing config: {}", e);
-                Self::default()
-            })
+        let mut raw = toml::from_str::<RawConfig>(&content)
+            .map_err(|e| format!("Config syntax error: {}", e))?;
+
+        raw.theme = raw.theme.with_overrides();
+        Ok(raw.into())
     }
 
     crate::getters! {

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -161,6 +161,14 @@ impl Theme {
         status_line_style => status_line,
     }
 
+    pub(crate) fn preview_selection_style(&self) -> Style {
+        self.preview.selection_style(&self.selection)
+    }
+
+    pub(crate) fn parent_selection_style(&self) -> Style {
+        self.parent.selection_style(&self.selection)
+    }
+
     pub(crate) fn separator_style(&self) -> Style {
         let default = Theme::builtin();
         if self.separator != default.separator {

--- a/src/config/theme/colorpair.rs
+++ b/src/config/theme/colorpair.rs
@@ -80,10 +80,6 @@ impl ColorPair {
         }
     }
 
-    pub(super) fn style(&self) -> Style {
-        Style::default().fg(self.fg).bg(self.bg)
-    }
-
     pub(super) fn style_or(&self, fallback: &ColorPair) -> Style {
         let resovled = self.resolve(fallback);
         Style::default().fg(resovled.fg).bg(resovled.bg)

--- a/src/config/theme/components.rs
+++ b/src/config/theme/components.rs
@@ -34,7 +34,7 @@ impl PaneTheme {
     /// Returns the selection style, falling back to the provided fallback if not set.
     /// If selection is None, falls back to the provided fallback ColorPair.
     /// If selection is Some, uses its style_or method with the fallback.
-    pub(crate) fn selection_style(&self) -> Style {
+    pub(super) fn selection_style(&self, global: &ColorPair) -> Style {
         if self.selection_mode == SelectionMode::Off {
             return Style::default();
         }
@@ -42,7 +42,7 @@ impl PaneTheme {
         let default = &Theme::builtin().selection;
         match self.selection {
             Some(pane_sel) => pane_sel.style_or(default),
-            None => default.style(),
+            None => global.style_or(default),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,17 +10,18 @@ pub(crate) mod utils;
 
 use std::io;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::cli::{CliAction, handle_args};
 use crate::config::Config;
 use crate::core::workers::Workers;
 use crate::utils::path::{resolve_initial_dir, validate_path};
 
-fn startup_container<'a>(
-    config: &'a Config,
+fn startup_container(
+    config: Arc<Config>,
     workers: &Workers,
     cli_paths: Option<Vec<PathBuf>>,
-) -> io::Result<app::AppContainer<'a>> {
+) -> io::Result<app::AppContainer> {
     let is_cli_request = cli_paths.is_some();
     let paths: Vec<PathBuf> = match cli_paths {
         Some(paths) => paths,
@@ -28,7 +29,7 @@ fn startup_container<'a>(
     };
 
     if paths.is_empty() {
-        let mut app = app::AppState::new(config)?;
+        let mut app = app::AppState::new(Arc::clone(&config))?;
         app.initialize(workers, None);
         return Ok(app::AppContainer::Single(Box::new(app)));
     }
@@ -41,7 +42,7 @@ fn startup_container<'a>(
 
         let path_str = path.to_string_lossy();
         if path_str == "." || path_str == "cwd" {
-            if let Ok(mut state) = app::AppState::new(config) {
+            if let Ok(mut state) = app::AppState::new(Arc::clone(&config)) {
                 state.initialize(workers, None);
                 tabs.push(state);
             }
@@ -52,7 +53,7 @@ fn startup_container<'a>(
                 return Err(io::Error::new(e.kind(), format!("{}: '{}'", e, path_str)));
             }
 
-            let mut state = app::AppState::from_dir(config, &target)?;
+            let mut state = app::AppState::from_dir(Arc::clone(&config), &target)?;
             state.initialize(workers, None);
             tabs.push(state);
         }
@@ -63,7 +64,7 @@ fn startup_container<'a>(
             if is_cli_request {
                 return Err(io::Error::other("The provided paths could not be opened"));
             }
-            let mut app = app::AppState::new(config)?;
+            let mut app = app::AppState::new(Arc::clone(&config))?;
             app.initialize(workers, None);
             Ok(app::AppContainer::Single(Box::new(app)))
         }
@@ -112,7 +113,7 @@ fn main() -> io::Result<()> {
 
     let workers = Workers::spawn();
 
-    let container = match startup_container(&config, &workers, cli_paths) {
+    let container = match startup_container(Arc::new(config), &workers, cli_paths) {
         Ok(cont) => cont,
         Err(e) => {
             eprintln!("[runa] Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,10 @@ fn main() -> io::Result<()> {
         return Ok(());
     }
 
-    let config = Config::load();
+    let config = Config::load().unwrap_or_else(|e| {
+        eprintln!("[runa] Config error: {}", e);
+        Config::default()
+    });
 
     let cli_paths = match action {
         CliAction::RunApp => None,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -81,7 +81,7 @@ pub(crate) fn render(
 
         let parent_pane_style = PaneStyles::new(theme_cfg)
             .with_entry(theme_cfg.parent().entry_style_or_theme())
-            .with_selection(theme_cfg.parent().selection_style());
+            .with_selection(theme_cfg.parent_selection_style());
 
         panes::draw_parent(
             frame,
@@ -163,7 +163,7 @@ pub(crate) fn render(
 
         let preview_pane_style = PaneStyles::new(theme_cfg)
             .with_entry(theme_cfg.preview().entry_style_or_theme())
-            .with_selection(theme_cfg.preview().selection_style());
+            .with_selection(theme_cfg.preview_selection_style());
 
         panes::draw_preview(
             frame,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -435,6 +435,7 @@ mod tests {
     use crate::Config;
     use crate::config::load::RawConfig;
     use std::error;
+    use std::sync::Arc;
 
     #[test]
     fn layout_chunks_with_config() -> Result<(), Box<dyn error::Error>> {
@@ -455,7 +456,7 @@ mod tests {
         let raw: RawConfig = toml::from_str(toml_content)?;
         let config = Config::from(raw);
 
-        let app = AppState::new(&config).expect("Failed to create AppState");
+        let app = AppState::new(Arc::new(config)).expect("Failed to create AppState");
 
         let chunks = layout_chunks(size, &app);
 

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -90,6 +90,10 @@ where
                             // full clear/reset
                             terminal.clear()?;
                         }
+                        KeypressResult::ReloadConfig => {
+                            root.reload_config();
+                            terminal.clear()?;
+                        }
                         KeypressResult::Tab(tab_act) => {
                             if let KeypressResult::Quit =
                                 app::handle_tab_action(&root.workers, &mut root.container, tab_act)

--- a/src/ui/widgets/overlays.rs
+++ b/src/ui/widgets/overlays.rs
@@ -351,6 +351,7 @@ const HELP_DATA: &[HelpSection] = &[
         entries: &[
             HelpEntry { key: InputKeys::Quit, desc: "Quit" },
             HelpEntry { key: InputKeys::KeybindHelp, desc: "Toggle keybind help" },
+            HelpEntry { key: InputKeys::Reload, desc: "Reload the configuration" },
         ],
     },
 ];
@@ -447,6 +448,7 @@ pub(crate) fn draw_keybind_help(frame: &mut Frame, app: &AppState, accent_style:
             InputKeys::SortByAccessed => keys.sort_by_accessed(),
             InputKeys::Quit => keys.quit(),
             InputKeys::KeybindHelp => keys.keybind_help(),
+            InputKeys::Reload => keys.reload(),
         }
     };
 


### PR DESCRIPTION
### Added
- Add a config reload keybind to reload the `runa.toml`

### Fixed
- Pane selection style now correctly applies the global `selection.fg/bg` for each pane. The individual pane overrides then apply the overridden colors to the pane styles.